### PR TITLE
Expand match metadata

### DIFF
--- a/src/Components/Common.js
+++ b/src/Components/Common.js
@@ -15,15 +15,15 @@ export const gqlProps = {
 export const  isBeta = () => window.location.pathname.split('/')[1] === 'beta' ? '/beta' : '';
 
 export const expandMatchMetadata = (md) => {
-        let output = '';
-        md.source_type === 'file' ? (
-            output += 'File Type: ' + md.file_type,
-            output += '\nFile Mime Type: ' + md.mime_type,
-            output += '\nFile MD5Sum: ' + md.md5sum,
-            'line' in md ? (
-                output += '\nMatching Line Number: ' + md.line_number,
-                output += '\nMatching Line: ' + decodeURIComponent(md.line)
-            ) : null)
-            : output += 'Process Name: ' + md.process_name;
-        return output;
-    };
+    let output = '';
+    md.source_type === 'file' ? (
+        output += 'File Type: ' + md.file_type,
+        output += '\nFile Mime Type: ' + md.mime_type,
+        output += '\nFile MD5Sum: ' + md.md5sum,
+        'line' in md ? (
+            output += '\nMatching Line Number: ' + md.line_number,
+            output += '\nMatching Line: ' + decodeURIComponent(md.line)
+        ) : null)
+        : output += 'Process Name: ' + md.process_name;
+    return output;
+};

--- a/src/Components/Common.js
+++ b/src/Components/Common.js
@@ -13,3 +13,17 @@ export const gqlProps = {
 };
 
 export const  isBeta = () => window.location.pathname.split('/')[1] === 'beta' ? '/beta' : '';
+
+export const expandMatchMetadata = (md) => {
+        let output = '';
+        md.source_type === 'file' ? (
+            output += 'File Type: ' + md.file_type,
+            output += '\nFile Mime Type: ' + md.mime_type,
+            output += '\nFile MD5Sum: ' + md.md5sum,
+            'line' in md ? (
+                output += '\nMatching Line Number: ' + md.line_number,
+                output += '\nMatching Line: ' + decodeURIComponent(md.line)
+            ) : null)
+            : output += 'Process Name: ' + md.process_name;
+        return output;
+    };

--- a/src/Components/SigDetailsTable/SigDetailsTable.js
+++ b/src/Components/SigDetailsTable/SigDetailsTable.js
@@ -85,6 +85,22 @@ const SigDetailsTable = ({ ruleName, affectedCount }) => {
     const onSort = (e, index, direction) =>
         stateSet({ type: 'setSortBy', payload: { index, direction }, tableVars: { orderBy: orderBy({ index, direction }), offset: 0 } });
 
+    const expandMatchMetadata = (md) => {
+        let output = ''
+        if (md['source_type'] == 'file') {
+            output += 'File Type: ' + md['file_type']
+            output += '\nFile Mime Type: ' + md['mime_type']
+            output += '\nFile MD5Sum: ' + md['md5sum']
+            if (md.hasOwnProperty('line')) {
+                output += '\nMatching Line Number: ' + md['line_number']
+                output += '\nMatching Line: ' + decodeURIComponent(md['line'])
+            }
+        } else {
+            output += 'Process Name: ' + md['process_name']
+        }
+        return output;
+    }
+
     const onCollapse = (e, rowKey, isOpen) => {
         const collapseRows = [...rows];
         const host = collapseRows[rowKey + 1].hostData;
@@ -96,7 +112,7 @@ Offset:${match.stringOffset}
 Match Data: ${match.stringData}
 Match Identifier: ${match.stringIdentifier}
 Match Scan Date: ${new Date(match.scanDate)}
-${match.metadata ? `Metadata:${match.metadata}` : ''}
+${match.metadata ? expandMatchMetadata(JSON.parse(match.metadata)) : ''}
 ${host.matches.length > 1 && key !== host.matches.length - 1 ? `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ` : ''}`).join('')}`}
             isDownloadEnabled isCopyEnabled/> }];

--- a/src/Components/SigDetailsTable/SigDetailsTable.js
+++ b/src/Components/SigDetailsTable/SigDetailsTable.js
@@ -86,20 +86,21 @@ const SigDetailsTable = ({ ruleName, affectedCount }) => {
         stateSet({ type: 'setSortBy', payload: { index, direction }, tableVars: { orderBy: orderBy({ index, direction }), offset: 0 } });
 
     const expandMatchMetadata = (md) => {
-        let output = ''
-        if (md['source_type'] == 'file') {
-            output += 'File Type: ' + md['file_type']
-            output += '\nFile Mime Type: ' + md['mime_type']
-            output += '\nFile MD5Sum: ' + md['md5sum']
-            if (md.hasOwnProperty('line')) {
-                output += '\nMatching Line Number: ' + md['line_number']
-                output += '\nMatching Line: ' + decodeURIComponent(md['line'])
+        let output = '';
+        if (md.source_type === 'file') {
+            output += 'File Type: ' + md.file_type;
+            output += '\nFile Mime Type: ' + md.mime_type;
+            output += '\nFile MD5Sum: ' + md.md5sum;
+            if ('line' in md) {
+                output += '\nMatching Line Number: ' + md.line_number;
+                output += '\nMatching Line: ' + decodeURIComponent(md.line);
             }
         } else {
-            output += 'Process Name: ' + md['process_name']
+            output += 'Process Name: ' + md.process_name;
         }
+
         return output;
-    }
+    };
 
     const onCollapse = (e, rowKey, isOpen) => {
         const collapseRows = [...rows];

--- a/src/Components/SigDetailsTable/SigDetailsTable.js
+++ b/src/Components/SigDetailsTable/SigDetailsTable.js
@@ -13,6 +13,7 @@ import {
 import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import CodeEditor from '../CodeEditor/CodeEditor';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import { expandMatchMetadata } from '../Common';
 import { GET_SIGNATURE_DETAILS_TABLE } from '../../operations/queries';
 import Loading from '../Loading/Loading';
 import MessageState from '../MessageState/MessageState';
@@ -84,23 +85,6 @@ const SigDetailsTable = ({ ruleName, affectedCount }) => {
 
     const onSort = (e, index, direction) =>
         stateSet({ type: 'setSortBy', payload: { index, direction }, tableVars: { orderBy: orderBy({ index, direction }), offset: 0 } });
-
-    const expandMatchMetadata = (md) => {
-        let output = '';
-        if (md.source_type === 'file') {
-            output += 'File Type: ' + md.file_type;
-            output += '\nFile Mime Type: ' + md.mime_type;
-            output += '\nFile MD5Sum: ' + md.md5sum;
-            if ('line' in md) {
-                output += '\nMatching Line Number: ' + md.line_number;
-                output += '\nMatching Line: ' + decodeURIComponent(md.line);
-            }
-        } else {
-            output += 'Process Name: ' + md.process_name;
-        }
-
-        return output;
-    };
 
     const onCollapse = (e, rowKey, isOpen) => {
         const collapseRows = [...rows];

--- a/src/Components/SysDetailsTable/SysDetailsTable.js
+++ b/src/Components/SysDetailsTable/SysDetailsTable.js
@@ -85,6 +85,20 @@ const SysDetailsTable = ({ systemId }) => {
     const onSort = (e, index, direction) =>
         stateSet({ type: 'setSortBy', payload: { index, direction }, tableVars: { orderBy: orderBy({ index, direction }), offset: 0 } });
 
+    const expandMatchMetadata = (md) => {
+        let output = ''
+        md['source_type'] == 'file' ? (
+            output += 'File Type: ' + md['file_type'],
+            output += '\nFile Mime Type: ' + md['mime_type'],
+            output += '\nFile MD5Sum: ' + md['md5sum'],
+            md.hasOwnProperty('line') ? (
+                output += '\nMatching Line Number: ' + md['line_number'],
+                output += '\nMatching Line: ' + decodeURIComponent(md['line'])
+            ) : null)
+        : output += 'Process Name: ' + md['process_name']
+        return output;
+    }
+
     const onCollapse = (e, rowKey, isOpen) => {
         const collapseRows = [...rows];
         const host = collapseRows[rowKey + 1].hostData;
@@ -96,7 +110,7 @@ Offset:${match.stringOffset}
 Match Data: ${match.stringData}
 Match Identifier: ${match.stringIdentifier}
 Match Scan Date: ${new Date(match.scanDate)}
-${match.metadata ? `Metadata:${match.metadata}` : ''}
+${match.metadata ? expandMatchMetadata(JSON.parse(match.metadata)) : ''}
 ${host.matches.length > 1 && key !== host.matches.length - 1 ? `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ` : ''}`).join('')}`}
             isDownloadEnabled isCopyEnabled/> }];

--- a/src/Components/SysDetailsTable/SysDetailsTable.js
+++ b/src/Components/SysDetailsTable/SysDetailsTable.js
@@ -86,18 +86,18 @@ const SysDetailsTable = ({ systemId }) => {
         stateSet({ type: 'setSortBy', payload: { index, direction }, tableVars: { orderBy: orderBy({ index, direction }), offset: 0 } });
 
     const expandMatchMetadata = (md) => {
-        let output = ''
-        md['source_type'] == 'file' ? (
-            output += 'File Type: ' + md['file_type'],
-            output += '\nFile Mime Type: ' + md['mime_type'],
-            output += '\nFile MD5Sum: ' + md['md5sum'],
-            md.hasOwnProperty('line') ? (
-                output += '\nMatching Line Number: ' + md['line_number'],
-                output += '\nMatching Line: ' + decodeURIComponent(md['line'])
+        let output = '';
+        md.source_type === 'file' ? (
+            output += 'File Type: ' + md.file_type,
+            output += '\nFile Mime Type: ' + md.mime_type,
+            output += '\nFile MD5Sum: ' + md.md5sum,
+            'line' in md ? (
+                output += '\nMatching Line Number: ' + md.line_number,
+                output += '\nMatching Line: ' + decodeURIComponent(md.line)
             ) : null)
-        : output += 'Process Name: ' + md['process_name']
+        : output += 'Process Name: ' + md.process_name;
         return output;
-    }
+    };
 
     const onCollapse = (e, rowKey, isOpen) => {
         const collapseRows = [...rows];

--- a/src/Components/SysDetailsTable/SysDetailsTable.js
+++ b/src/Components/SysDetailsTable/SysDetailsTable.js
@@ -13,6 +13,7 @@ import {
 import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import CodeEditor from '../CodeEditor/CodeEditor';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import { expandMatchMetadata } from '../Common';
 import { GET_SYSTEMS_DETAILS_TABLE_PAGE } from '../../operations/queries';
 import Loading from '../Loading/Loading';
 import MessageState from '../MessageState/MessageState';
@@ -84,20 +85,6 @@ const SysDetailsTable = ({ systemId }) => {
 
     const onSort = (e, index, direction) =>
         stateSet({ type: 'setSortBy', payload: { index, direction }, tableVars: { orderBy: orderBy({ index, direction }), offset: 0 } });
-
-    const expandMatchMetadata = (md) => {
-        let output = '';
-        md.source_type === 'file' ? (
-            output += 'File Type: ' + md.file_type,
-            output += '\nFile Mime Type: ' + md.mime_type,
-            output += '\nFile MD5Sum: ' + md.md5sum,
-            'line' in md ? (
-                output += '\nMatching Line Number: ' + md.line_number,
-                output += '\nMatching Line: ' + decodeURIComponent(md.line)
-            ) : null)
-            : output += 'Process Name: ' + md.process_name;
-        return output;
-    };
 
     const onCollapse = (e, rowKey, isOpen) => {
         const collapseRows = [...rows];

--- a/src/Components/SysDetailsTable/SysDetailsTable.js
+++ b/src/Components/SysDetailsTable/SysDetailsTable.js
@@ -95,7 +95,7 @@ const SysDetailsTable = ({ systemId }) => {
                 output += '\nMatching Line Number: ' + md.line_number,
                 output += '\nMatching Line: ' + decodeURIComponent(md.line)
             ) : null)
-        : output += 'Process Name: ' + md.process_name;
+            : output += 'Process Name: ' + md.process_name;
         return output;
     };
 


### PR DESCRIPTION
Having a bit of a test here and looking for feedback.  Seeing the metadata displayed just as string looked a bit blech.  Would look much better if it were expanded into its component fields, like in the screenshot!  However my Javascript foo is weak (or more like its too Python-ish) and I'm sure there is a much more Javascript-ish or React-ish way of implementing this, so feedback is most welcome.  Allen, you also don't seem to be fan of 'if' statements so I tried writing one of the functions without 'ifs'.  Looks a bit iffy though.

![signatures_expanded_metadata](https://user-images.githubusercontent.com/4008744/128337841-83d90189-ce48-4ec6-8401-bf8572168f4e.png)

![systems_expanded_metadata](https://user-images.githubusercontent.com/4008744/128337868-d7b59479-0b30-40b1-895b-a4d8fce03818.png)

