### PR TITLE
Add checks to parsing metadata in case fields are missing

### DIFF
--- a/src/Components/Common.js
+++ b/src/Components/Common.js
@@ -18,31 +18,20 @@ const gqlProps = {
 
 const isBeta = () => window.location.pathname.split('/')[1] === 'beta' ? '/beta' : '';
 
-/* eslint-disable max-len, padding-line-between-statements */
-export const expandMatchMetadata = (md) => {
-    let output = 'Source type: ' + md.source_type;
-    if (md.source_type === 'file') {
-        // scanned source was a file, parse its metadata (if any)
-        if ('file_type' in md) {
-            output += '\nFile Type: ' + md.file_type;
-            output += '\nFile Mime Type: ' + md.mime_type;
-            output += '\nFile MD5Sum: ' + md.md5sum;
-            'line' in md && (output += '\nMatching Line Number: ' + md.line_number, output += '\nMatching Line: ' + decodeURIComponent(md.line));
-        } else {
-            output += ' (no metadata: Match Source is missing)';
-        };
-    } else {
-        // scanned source was a process, parse its metadata (if any)
-        if ('process_name' in md) {
-            output += '\nProcess Name: ' + md.process_name;
-        } else {
-            output += ' (no metadata: Match Source is missing)';
-        };
-    };
+// Parse the match.metadata object and return a string of its components each on a separate line
+const expandMatchMetadata = (md) => {
+    // eslint-disable-next-line max-len
+    const output = `Source Type: ${md.source_type} ${md.md5sum || md.process_name ? '' : '(no metadata: Match Source is missing)'}\
+    ${md.source_type === 'file' ?
+    `${md.md5sum ? `\nFile Type: ${md.file_type}\
+    \nFile Mime Type: ${md.mime_type}\
+    \nFile MD5Sum: ${md.md5sum}\
+    ${md.line ? `\nLine Number: ${md.line_number}\
+    \nLine: ${decodeURIComponent(md.line)}` :''}`:''}`
+    : `${md.process_name ? `\nProcess Name: ${md.process_name}`:''}`}`;
 
     return output;
 };
-/* eslint-enable max-len, padding-line-between-statements */
 
 const totalMatchesTitle = ({ tooltip, title }) => (<span>
     {title}

--- a/src/Components/Common.js
+++ b/src/Components/Common.js
@@ -18,16 +18,13 @@ const gqlProps = {
 
 const isBeta = () => window.location.pathname.split('/')[1] === 'beta' ? '/beta' : '';
 
-// Parse the match.metadata object and return a string of its components each on a separate line
+// Parse the match.metadata object and return a string of its 'key: value' items each on a separate line
 const expandMatchMetadata = (md) => {
     // eslint-disable-next-line max-len
     const output = `Source Type: ${md.source_type} ${md.md5sum || md.process_name ? '' : '(no metadata: Match Source is missing)'}\
     ${md.source_type === 'file' ?
-        `${md.md5sum ? `\nFile Type: ${md.file_type}\
-    \nFile Mime Type: ${md.mime_type}\
-    \nFile MD5Sum: ${md.md5sum}\
-    ${md.line ? `\nLine Number: ${md.line_number}\
-    \nLine: ${decodeURIComponent(md.line)}` : ''}` : ''}`
+        `${md.md5sum ? `\nFile Type: ${md.file_type}\nFile Mime Type: ${md.mime_type}\nFile MD5Sum: ${md.md5sum}\
+         ${md.line ? `\nLine Number: ${md.line_number}\nLine: ${decodeURIComponent(md.line)}` : ''}` : ''}`
         : `${md.process_name ? `\nProcess Name: ${md.process_name}` : ''}`}`;
 
     return output;

--- a/src/Components/Common.js
+++ b/src/Components/Common.js
@@ -18,24 +18,31 @@ const gqlProps = {
 
 const isBeta = () => window.location.pathname.split('/')[1] === 'beta' ? '/beta' : '';
 
+/* eslint-disable max-len, padding-line-between-statements */
 export const expandMatchMetadata = (md) => {
-    let output = "Source type: " + md.source_type;
-    md.source_type === 'file' ?
-        'file_type' in md ? (
-            output += '\nFile Type: ' + md.file_type,
-            output += '\nFile Mime Type: ' + md.mime_type,
-            output += '\nFile MD5Sum: ' + md.md5sum,
-            'line' in md && (
-                output += '\nMatching Line Number: ' + md.line_number,
-                output += '\nMatching Line: ' + decodeURIComponent(md.line)
-            )) : output += ' (no metadata: source is missing)'
-        : null;
-    md.source_type === 'process' ?
-        'process_name' in md ? output += 'Process Name: ' + md.process_name
-                             : output += ' (no metadata: source is missing)'
-        : null;
+    let output = 'Source type: ' + md.source_type;
+    if (md.source_type === 'file') {
+        // scanned source was a file, parse its metadata (if any)
+        if ('file_type' in md) {
+            output += '\nFile Type: ' + md.file_type;
+            output += '\nFile Mime Type: ' + md.mime_type;
+            output += '\nFile MD5Sum: ' + md.md5sum;
+            'line' in md && (output += '\nMatching Line Number: ' + md.line_number, output += '\nMatching Line: ' + decodeURIComponent(md.line));
+        } else {
+            output += ' (no metadata: Match Source is missing)';
+        };
+    } else {
+        // scanned source was a process, parse its metadata (if any)
+        if ('process_name' in md) {
+            output += '\nProcess Name: ' + md.process_name;
+        } else {
+            output += ' (no metadata: Match Source is missing)';
+        };
+    };
+
     return output;
 };
+/* eslint-enable max-len, padding-line-between-statements */
 
 const totalMatchesTitle = ({ tooltip, title }) => (<span>
     {title}

--- a/src/Components/Common.js
+++ b/src/Components/Common.js
@@ -18,17 +18,22 @@ const gqlProps = {
 
 const isBeta = () => window.location.pathname.split('/')[1] === 'beta' ? '/beta' : '';
 
-const expandMatchMetadata = (md) => {
-    let output = '';
-    md.source_type === 'file' ? (
-        output += 'File Type: ' + md.file_type,
-        output += '\nFile Mime Type: ' + md.mime_type,
-        output += '\nFile MD5Sum: ' + md.md5sum,
-        'line' in md ? (
-            output += '\nMatching Line Number: ' + md.line_number,
-            output += '\nMatching Line: ' + decodeURIComponent(md.line)
-        ) : null)
-        : output += 'Process Name: ' + md.process_name;
+export const expandMatchMetadata = (md) => {
+    let output = "Source type: " + md.source_type;
+    md.source_type === 'file' ?
+        'file_type' in md ? (
+            output += '\nFile Type: ' + md.file_type,
+            output += '\nFile Mime Type: ' + md.mime_type,
+            output += '\nFile MD5Sum: ' + md.md5sum,
+            'line' in md && (
+                output += '\nMatching Line Number: ' + md.line_number,
+                output += '\nMatching Line: ' + decodeURIComponent(md.line)
+            )) : output += ' (no metadata: source is missing)'
+        : null;
+    md.source_type === 'process' ?
+        'process_name' in md ? output += 'Process Name: ' + md.process_name
+                             : output += ' (no metadata: source is missing)'
+        : null;
     return output;
 };
 

--- a/src/Components/Common.js
+++ b/src/Components/Common.js
@@ -20,13 +20,10 @@ const isBeta = () => window.location.pathname.split('/')[1] === 'beta' ? '/beta'
 
 // Parse the match.metadata object and return a string of its 'key: value' items each on a separate line
 const expandMatchMetadata = (md) => {
-    // eslint-disable-next-line max-len
-    const output = `Source Type: ${md.source_type} ${md.md5sum || md.process_name ? '' : '(no metadata: Match Source is missing)'}\
-    ${md.source_type === 'file' ?
-        `${md.md5sum ? `\nFile Type: ${md.file_type}\nFile Mime Type: ${md.mime_type}\nFile MD5Sum: ${md.md5sum}\
-         ${md.line ? `\nLine Number: ${md.line_number}\nLine: ${decodeURIComponent(md.line)}` : ''}` : ''}`
-        : `${md.process_name ? `\nProcess Name: ${md.process_name}` : ''}`}`;
-
+    let output = `Source Type: ${md.source_type} ${md.md5sum || md.process_name ? '' : '(no metadata: Match Source is missing)'}`;
+    output += md.md5sum ? `\nFile Type: ${md.file_type}\nFile Mime Type: ${md.mime_type}\nFile MD5Sum: ${md.md5sum}` : '';
+    output += md.line ? `\nLine Number: ${md.line_number}\nLine: ${decodeURIComponent(md.line)}` : '';
+    output += md.process_name ? `\nProcess Name: ${md.process_name}` : '';
     return output;
 };
 

--- a/src/Components/Common.js
+++ b/src/Components/Common.js
@@ -23,12 +23,12 @@ const expandMatchMetadata = (md) => {
     // eslint-disable-next-line max-len
     const output = `Source Type: ${md.source_type} ${md.md5sum || md.process_name ? '' : '(no metadata: Match Source is missing)'}\
     ${md.source_type === 'file' ?
-    `${md.md5sum ? `\nFile Type: ${md.file_type}\
+        `${md.md5sum ? `\nFile Type: ${md.file_type}\
     \nFile Mime Type: ${md.mime_type}\
     \nFile MD5Sum: ${md.md5sum}\
     ${md.line ? `\nLine Number: ${md.line_number}\
-    \nLine: ${decodeURIComponent(md.line)}` :''}`:''}`
-    : `${md.process_name ? `\nProcess Name: ${md.process_name}`:''}`}`;
+    \nLine: ${decodeURIComponent(md.line)}` : ''}` : ''}`
+        : `${md.process_name ? `\nProcess Name: ${md.process_name}` : ''}`}`;
 
     return output;
 };


### PR DESCRIPTION
Converted the function to having if statements :scream: Much easier for this python programmer to read it.  In the screenshot below, the circle with the metadata I let the scan finish before uploading, but the circle without the metadata, I killed the process before the scan had finshed, so it wasn't able to collect metadata about the process.

![metadata_checks](https://user-images.githubusercontent.com/4008744/128444891-d70986c0-cc6c-405a-8f06-521e47132da2.png)
