### PR TITLE
Change wording when no metadata available for a scan match

### DIFF
--- a/src/Components/Common.js
+++ b/src/Components/Common.js
@@ -20,7 +20,7 @@ const isBeta = () => window.location.pathname.split('/')[1] === 'beta' ? '/beta'
 
 // Parse the match.metadata object and return a string of its 'key: value' items each on a separate line
 const expandMatchMetadata = (md) => {
-    let output = `Source Type: ${md.source_type} ${md.md5sum || md.process_name ? '' : '(no metadata: Match Source is missing)'}`;
+    let output = `Source Type: ${md.source_type} ${md.md5sum || md.process_name ? '' : '(no additional metadata)'}`;
     output += md.md5sum ? `\nFile Type: ${md.file_type}\nFile Mime Type: ${md.mime_type}\nFile MD5Sum: ${md.md5sum}` : '';
     output += md.line ? `\nLine Number: ${md.line_number}\nLine: ${decodeURIComponent(md.line)}` : '';
     output += md.process_name ? `\nProcess Name: ${md.process_name}` : '';


### PR DESCRIPTION
The missing metadata may not be because the Source is missing.  Customer might have set metadata=False in config file.

![no_additional_metadata](https://user-images.githubusercontent.com/4008744/133011786-3f06a70c-e170-41cc-869a-6de1ad62df3e.png)
