### PR TITLE
Fix match detail card not expanding

### DIFF
--- a/src/Components/SysDetailsTable/SysDetailsTable.js
+++ b/src/Components/SysDetailsTable/SysDetailsTable.js
@@ -101,7 +101,7 @@ Offset:${match.stringOffset}
 Match Data: ${match.stringData}
 Match Identifier: ${match.stringIdentifier}
 Match Scan Date: ${new Date(match.scanDate).toUTCString()}
-${match.metadata ? expandMatchMetadata(JSON.parse(match.metadata)) : ''}
+${match.metadata ? expandMatchMetadata(JSON.parse(match.metadata.replaceAll('\n', ''))) : ''}
 ${host.matches.length > 1 && key !== host.matches.length - 1 ? `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ` : ''}`).join('')}`}
             isDownloadEnabled isCopyEnabled/> }];


### PR DESCRIPTION
https://issues.redhat.com/browse/YARA-241

The json.parse was failing on some match metadata because of errant new lines.