### PR TITLE
Fix counts over 1000 showing as NaN

### DIFF
--- a/src/Components/ChartCard/ChartCard.js
+++ b/src/Components/ChartCard/ChartCard.js
@@ -30,8 +30,8 @@ const ChartCard = ({ sysStats, chartStats }) => {
                     dataSize='md'
                     description={intl.formatMessage(messages.analysisRunAcross,
                         {
-                            hosts: sysStatsData?.hosts?.totalCount?.toLocaleString(),
-                            matches: sysStatsData?.ruleStats?.matchedCount?.toLocaleString(),
+                            hosts: sysStatsData?.hosts?.totalCount,
+                            matches: sysStatsData?.ruleStats?.matchedCount,
                             strong: (str) => strong(str)
                         })}
                     layout='horizontal'


### PR DESCRIPTION
https://issues.redhat.com/browse/YARA-248
Numbers above 1000 were showing up as NaN because they were being double formatted.  The first format added a comma and the second format then failed because it expected a number, not a string.