### PR TITLE
Match signature name exactly on signature detail page

### DIFF
--- a/src/operations/queries.js
+++ b/src/operations/queries.js
@@ -47,7 +47,7 @@ QuerySigPage($offset: Int = 0, $limit: Int = 10, $orderBy: [RulesOrderBy!], $rul
 }${Signatures.RuleDetails}`;
 
 export const GET_SIGNATURE_DETAILS_PAGE = gql`query QuerySigDetailsPage($ruleName: String)  {
-  rulesList(ruleName: $ruleName)  {
+  rulesList(condition: {name: $ruleName})  {
       ...RuleDetails
       ...ExtraRuleDetails
   }
@@ -64,7 +64,7 @@ export const GET_MALWARE_COUNT = gql`query QuerySigPage {
 
 export const GET_SIGNATURE_DETAILS_TABLE = gql`query QuerySigPage($offset: Int = 0, $limit: Int = 10, $orderBy: [HostWithMatchesOrderBy!],
 $ruleName: String, $displayName: String)  {
-  rulesList(ruleName: $ruleName)  {
+  rulesList(condition: {name: $ruleName})  {
     affectedHostsList (offset: $offset, first: $limit, orderBy: $orderBy, displayName: $displayName) {
       displayName
         lastScanDate


### PR DESCRIPTION
Previously we were using the fuzzy search match to retrieve a signature for the signature details page.  The signature detail page corresponds to an exact signature. Therefore we do an exact match.