### PR TITLE
Enable mssql app filter

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,4 +1,5 @@
 parser: '@babel/eslint-parser'
+root: true
 settings:
   react:
     version: '16.0'

--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,7 @@ const App = (props) => {
         }),
         []
     );
-
+    
     useEffect(() => {
         insights.chrome.init();
         const baseComponentUrl = pathname.split('/')[4];

--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,7 @@ const App = (props) => {
         }),
         []
     );
-    
+
     useEffect(() => {
         insights.chrome.init();
         const baseComponentUrl = pathname.split('/')[4];

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -11,6 +11,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { cache } from './store/cache';
 import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers/helpers';
 import { init, RegistryContext } from './store';
+import { globalFilters } from './store/cache';
 import logger from 'redux-logger';
 import messages from '../locales/data.json';
 import { setContext } from '@apollo/client/link/context';
@@ -46,8 +47,11 @@ const AppEntry = ({ useLogger, connectToDevTools }) => {
                 const [workloads, SID, selectedTags] =
                 insights.chrome?.mapGlobalFilter?.(data, false, true) || [];
                 tags.current =  selectedTags?.join(',') || '';
-                selectedWorkloads.current = workloads  || {};
+
+                selectedWorkloads.current = workloads || {};
                 selectedSID.current = SID || [];
+
+                globalFilters({ workloads, SID, selectedTags });
 
                 client.resetStore();
             });

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -27,6 +27,8 @@ const AppEntry = ({ useLogger, connectToDevTools }) => {
             ...headers,
             ...(tags.current?.length && { 'insights-tags': `${tags.current}` }),
             ...(selectedWorkloads.current?.SAP?.isSelected && { 'insights-sap-system': true }),
+            ...(selectedWorkloads.current['Ansible Automation Platform']?.isSelected && { 'insights-ansible-system': true }),
+            ...(selectedWorkloads.current['Microsoft SQL']?.isSelected && { 'insights-mssql-system': true }),
             ...(selectedSID.current?.length && { 'insights-sap-sids': `${selectedSID.current}` })
         }
     }));

--- a/src/Components/SysTable/SysTable.js
+++ b/src/Components/SysTable/SysTable.js
@@ -18,6 +18,7 @@ import { gqlProps } from '../Common';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
 import { RegistryContext } from '../../store';
+import { globalFilters } from '../../store/cache';
 import { useDispatch } from 'react-redux';
 
 const SysTable = () => {
@@ -80,7 +81,12 @@ const SysTable = () => {
                 isStickyHeader: true
             }}
             noSystemsTable={<MessageState className='pf-c-card' icon={SearchIcon} variant='large' title={intl.formatMessage(messages.noResults)}
-                text={intl.formatMessage(messages.noResultsMatch)} />}
+                text={intl.formatMessage(messages.noResultsMatch)}/>}
+            customFilters={{
+                malwareParams: {
+                    ...globalFilters()
+                }
+            }}
         />
     </React.Fragment>;
 };

--- a/src/Routes/Systems/Systems.js
+++ b/src/Routes/Systems/Systems.js
@@ -11,6 +11,7 @@ import { useIntl } from 'react-intl';
 import { useQuery } from '@apollo/client';
 import { withRouter } from 'react-router-dom';
 import EmptyAccount from '../../Components/SharedComponents/EmptyAccount';
+import { globalFilters } from '../../store/cache';
 
 const SysTable = lazy(() => import(/* webpackChunkName: 'SigTable' */ '../../Components/SysTable/SysTable'));
 const StatusCard = lazy(() => import(/* webpackChunkName: 'StatusCard' */ '../../Components/StatusCard/StatusCard'));
@@ -28,8 +29,8 @@ const Systems = () => {
             </Title>
         </PageHeader>
         <Main>
-            {sigPageData.data?.hosts?.totalCount === 0 && <EmptyAccount message={intl.formatMessage(messages.emptyAccountTableBody)} />
-                || <Grid hasGutter>
+            {(sigPageData.data?.hosts?.totalCount === 0 && !globalFilters()) ? <EmptyAccount message={intl.formatMessage(messages.emptyAccountTableBody)} />
+                : (<Grid hasGutter>
                     <GridItem lg={6} md={5} sm={12}>
                         <Suspense fallback={<Loading />}><StatusCard {...{ noSigData: true, ...sigPageData }} noSigData/></Suspense>
                     </GridItem>
@@ -39,7 +40,7 @@ const Systems = () => {
                     <GridItem span={12}>
                         <Suspense fallback={<Loading />}><SysTable /></Suspense>
                     </GridItem>
-                </Grid>
+                </Grid>)
             }
         </Main>
     </React.Fragment>;

--- a/src/Routes/Systems/Systems.js
+++ b/src/Routes/Systems/Systems.js
@@ -29,7 +29,8 @@ const Systems = () => {
             </Title>
         </PageHeader>
         <Main>
-            {(sigPageData.data?.hosts?.totalCount === 0 && !globalFilters()) ? <EmptyAccount message={intl.formatMessage(messages.emptyAccountTableBody)} />
+            {(sigPageData.data?.hosts?.totalCount === 0 && !globalFilters())
+                ? <EmptyAccount message={intl.formatMessage(messages.emptyAccountTableBody)} />
                 : (<Grid hasGutter>
                     <GridItem lg={6} md={5} sm={12}>
                         <Suspense fallback={<Loading />}><StatusCard {...{ noSigData: true, ...sigPageData }} noSigData/></Suspense>

--- a/src/store/cache.js
+++ b/src/store/cache.js
@@ -4,6 +4,7 @@ import { InMemoryCache, makeVar } from '@apollo/client';
 export const hasMalware = makeVar(false);
 export const sigTableFilters = makeVar({});
 export const sysTableFilters = makeVar({});
+export const globalFilters  = makeVar({});
 export const cache = new InMemoryCache({
     typePolicies: {
         Query: {


### PR DESCRIPTION
1. Enables MSSQL and AAP filters. We need to send **insights-mssql-system** and **insights-ansible-system** with the Appollo client request headers to filter by respective new filters. 

2. On stage/beta env, systems table is not reacting to global filter changes. This is fixed by storing changed global filters in Appollo client cache and providing those filters into customFilters prop of the InventoryTable component to force the table reload new data. According to docs, saving any data type to that cache is safe.

3. Fixes Lint configuration and errors. 
