### PR TITLE
feat(YARA-395): TableTools Sorting rework 

### DIFF
--- a/src/Components/SigDetailsTable/SigDetailsTable.js
+++ b/src/Components/SigDetailsTable/SigDetailsTable.js
@@ -166,9 +166,15 @@ ${host.matches.length > 1 && key !== host.matches.length - 1 ? `~~~~~~~~~~~~~~~~
             }}
             filterConfig={{ items: filterConfigItems }}
         />
-        <Table className='sigTable' aria-label='Signature Details table'
-            rows={rows} cells={columns} onCollapse={onCollapse}
-            onSort={onSort} sortBy={sortBy} isStickyHeader>
+        <Table
+            className='sigTable'
+            aria-label='Signature Details table'
+            rows={rows}
+            cells={columns}
+            onCollapse={onCollapse}
+            onSort={onSort}
+            sortBy={data?.rulesList[0]?.affectedHosts?.totalCount > 0 ? sortBy : undefined}
+            isStickyHeader>
             <TableHeader />
             <TableBody />
         </Table>

--- a/src/Components/SigTable/SigTable.js
+++ b/src/Components/SigTable/SigTable.js
@@ -214,10 +214,15 @@ const SigTable = () => {
             filterConfig={{ items: filterConfigItems }}
             activeFiltersConfig={activeFiltersConfig}
         />
-        <Table className='sigTable' aria-label='Signature table'
+        <Table
+            className='sigTable'
+            aria-label='Signature table'
             onCollapse={onCollapse}
             rows={rows} cells={columns}
-            onSort={onSort} sortBy={sortBy} isStickyHeader>
+            onSort={onSort}
+            sortBy={sigTableData?.rulesList?.length > 0 ? sortBy : undefined}
+            isStickyHeader
+        >
             <TableHeader />
             <TableBody />
         </Table>


### PR DESCRIPTION
This PR originally used the tabletools PR from frontend components, but that has since been removed. Now this PR adds logic to the sorting so that when there are no systems on the table, sorting is disabled. 

To test simply navigate to the three tables within malware and get the table to render no systems. 
Then make sure sorting is disabled. 
This PR has to do with this ticket: https://issues.redhat.com/browse/YARA-395 , the ticket is fairly old, and the majority of the items it addresses are gone/ already reworked. This is the last of the items.

P.S I also added some formatting changes in one of the files just for easier readability 