### PR TITLE
Add temporary /beta redirect page to prod-stable

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -2,16 +2,10 @@
 import React, { Suspense, lazy } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
-import { Permissions } from './Components/Permissions';
-
-const SigRoutes = lazy(() => import(/* webpackChunkName: "Signatures" */ './Routes/Signatures/Routes'));
-const SysRoutes = lazy(() => import(/* webpackChunkName: "Systems" */ './Routes/Systems/Routes'));
+const TemporaryBetaPageRoute = lazy(() => import(/* webpackChunkName: "TemporaryBetaPage" */ './Routes/TemporaryBetaPage/TemporaryBetaPage'));
 
 const paths = [
-    { title: 'Signatures', path: '/signatures:?', render: ()=><Permissions><SigRoutes /></Permissions> },
-    { title: 'Signatures', path: '/signatures', render: ()=><Permissions><SigRoutes /></Permissions> },
-    { title: 'Systems', path: '/systems:?', render: ()=><Permissions><SysRoutes /></Permissions> },
-    { title: 'Systems', path: '/systems', render: ()=><Permissions><SysRoutes /></Permissions> }
+    { title: 'Signatures', path: '/signatures', render: ()=> <TemporaryBetaPageRoute /> }
 ];
 
 export const Routes = () => (
@@ -23,9 +17,9 @@ export const Routes = () => (
                     {...path}
                 />
             ))}
-            <Redirect path="/signatures" to={`${paths[1].path}`} push />
+            <Redirect path="/signatures" to={`${paths[0].path}`} push />
             {/* Finally, catch all unmatched routes */}
-            <Redirect path="*" to={`${paths[1].path}`} push />
+            <Redirect path="*" to={`${paths[0].path}`} push />
         </Switch>
     </Suspense>
 );

--- a/src/Routes/TemporaryBetaPage/TemporaryBetaPage.js
+++ b/src/Routes/TemporaryBetaPage/TemporaryBetaPage.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Bullseye, Button, Title } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+const TemporaryBetaPage = () => {
+    const onClick = (event) => {
+        const isMetaKey = event.ctrlKey || event.metaKey || event.which === 2;
+        const url = `${document.baseURI}beta/insights/malware`;
+        isMetaKey ? window.open(url) : (window.location.href = url);
+    };
+
+    return (
+        <Bullseye>
+            <div
+                className="chr-c-navigation__beta-info-modal"
+                style={{ maxWidth: 800 }}
+            >
+                <InfoCircleIcon size="xl" className="info-icon" />
+                <Title headingLevel="h4" size="xl">
+                    {`Malware is only available in our Beta Environment`}
+                </Title>
+                <div>
+                    Try this feature in our Beta Environment on console.redhat.com/beta.
+                    The Beta Environment allows you to interact with new features in an
+                    active development space. Because beta pre-release software is still
+                    being developed, you may encounter bugs or flaws in availability,
+                    stability, data, or performance.
+                </div>
+                <div>
+                    After you use a feature in beta, you’ll stay in the Beta Environment
+                    until you manually exit the beta release. Leave the Beta Environment
+                    any time by clicking on the settings (gear) icon or beta icon in the
+                    top toolbar.
+                </div>
+                <div className="pf-u-pt-md">
+                    <Button key="confirm" variant="primary" onClick={onClick}>
+                        Use feature in beta
+                    </Button>
+                </div>
+                <div>
+                    <a
+                        href="https://access.redhat.com/support/policy/updates/cloud-redhat/lifecycle"
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        Learn more about Beta Environment <ExternalLinkAltIcon />
+                    </a>
+                </div>
+            </div>
+        </Bullseye>
+    );
+};
+
+export default TemporaryBetaPage;


### PR DESCRIPTION
Ticket: [ESSNTL-3360](https://issues.redhat.com/browse/ESSNTL-3360).

![malware](https://user-images.githubusercontent.com/8426204/194872206-6d79626e-59b1-495c-8d90-2b388fc73d1a.png)

Prod-stable should contain only a page redirecting to /beta enviroment, this is a workaround to fix a missing feature in Insights Chrome, where clicking app link with beta chip feature should display modal with button to navigate to prod/beta. This modal is not always launched and could cause "Something went wrong" page. This PR fixes this by copying the modal contents into prod/stable as a singular page which serves as a fallback when modal is not shown. This is a temporary solution until Malware is launched into prod/stable completely.

Mockups: https://www.sketch.com/s/e7ea499d-f677-45be-aba7-a3a268fbe992/a/KvevQZ1 the modal contents should be moved into a page.

Malware app is currently not in prod-stable navigation but should land there pretty soon.

This PR is a bit hard to explain so if you need further clarification let me know.

If you want to see an example of how it looks in practice Vulnerability for OpenShift has the same feature:
https://console.redhat.com/openshift/insights/vulnerability/cves