### PR TITLE
Use nulls last match sorting

### DIFF
--- a/src/Components/SigTable/SigTable.js
+++ b/src/Components/SigTable/SigTable.js
@@ -35,16 +35,16 @@ const initialState = {
     tableVars: {
         limit: 10,
         offset: 0,
-        orderBy: 'HOST_COUNT_DESC',
+        orderBy: 'LAST_MATCH_DATE_NULLS_LAST_DESC',
         ruleName: ''
     },
     sortBy: {
-        index: 3,
+        index: 4,
         direction: SortByDirection.desc
     },
     rows: []
 };
-const sortIndices = { 1: 'NAME', 2: 'HAS_MATCH', 3: 'HOST_COUNT', 4: 'LAST_MATCH_DATE' };
+const sortIndices = { 1: 'NAME', 2: 'HAS_MATCH', 3: 'HOST_COUNT', 4: 'LAST_MATCH_DATE_NULLS_LAST' };
 const orderBy = ({ index, direction }) => `${sortIndices[index]}_${direction === SortByDirection.asc ? 'ASC' : 'DESC'}`;
 
 const tableReducer = (state, action) => {


### PR DESCRIPTION
Added a backend option to sort last match with nulls last which should make a lot more sense.