### PR TITLE
fix(YARA-395): Update sorting on sysDetails Table

### DIFF
--- a/src/Components/SysDetailsTable/SysDetailsTable.js
+++ b/src/Components/SysDetailsTable/SysDetailsTable.js
@@ -151,7 +151,10 @@ ${host.matches.length > 1 && key !== host.matches.length - 1 ? `~~~~~~~~~~~~~~~~
         />
         <Table className='sigTable' aria-label='Signature Details table'
             rows={rows} cells={columns} onCollapse={onCollapse}
-            onSort={onSort} sortBy={sortBy} isStickyHeader>
+            onSort={onSort}
+            sortBy={data?.host?.affectedRules?.totalCount > 0 ? sortBy : undefined}
+            isStickyHeader
+        >
             <TableHeader />
             <TableBody />
         </Table>


### PR DESCRIPTION
Disables sorting on systems details page when there are no rules on the table. 