### PR TITLE
fix(ESSNTL-3719): Make the group column sortable

### DIFF
--- a/src/Components/SysTable/constants.js
+++ b/src/Components/SysTable/constants.js
@@ -9,7 +9,6 @@ import messages from '../../Messages';
 import StatusLabel from '../StatusLabel/StatusLabel';
 import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
-import isEmpty from 'lodash/isEmpty';
 import { InsightsLink } from '@redhat-cloud-services/frontend-components/InsightsLink';
 
 const cache = createIntlCache();
@@ -120,16 +119,6 @@ export const mergedColumns = (defaultColumns) => {
             undefined : {
                 ...(isStringCol ? { key: column } : column),
                 ...defaultColumn,
-                ...(column.key === 'groups' ?
-                    {
-                        renderFunc: (groups) => isEmpty(groups) ?
-                            'N/A'
-                            :
-                            <InsightsLink to={`/groups/${groups[0].id}`} app="inventory">
-                                {groups[0].name}
-                            </InsightsLink>
-                    }
-                    : {}),
                 props: {
                     ...defaultColumn?.props,
                     ...column?.props

--- a/src/Components/SysTable/constants.js
+++ b/src/Components/SysTable/constants.js
@@ -46,7 +46,8 @@ export const columns = [
         title: 'Group',
         key: 'groups',
         sortBy: ['GROUP_NAME'],
-        requiresDefault: true
+        requiresDefault: true,
+        props: { isStatic: false }
     },
     {
         title: 'Tags',


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-3719.

- make `/malware/systems`, Systems table render the Group column as a plain text
- make the column also sortable.

## How to test

Navigate to /malware/systems, and make sure you are able to sort by the Group column, and also the group names are rendered as a plain text, not links.

## Screenshots

![image](https://github.com/RedHatInsights/malware-detection-frontend/assets/31385370/818f3251-1744-476a-a248-27e6a0978053)

