### PR TITLE
Fixes for RHINENG-2254

### DIFF
--- a/src/Components/SigTable/SigTable.js
+++ b/src/Components/SigTable/SigTable.js
@@ -36,7 +36,7 @@ const initialState = {
     tableVars: {
         limit: 10,
         offset: 0,
-        orderBy: 'LAST_MATCH_DATE_NULLS_LAST_DESC',
+        orderBy: ['LAST_MATCH_DATE_NULLS_LAST_DESC', 'NAME_ASC'],
         ruleName: ''
     },
     sortBy: {
@@ -47,7 +47,11 @@ const initialState = {
     selectedSigs: []
 };
 const sortIndices = { 2: 'NAME', 3: 'HAS_MATCH', 4: 'HOST_COUNT', 5: 'LAST_MATCH_DATE_NULLS_LAST' };
-const orderBy = ({ index, direction }) => `${sortIndices[index]}_${direction === SortByDirection.asc ? 'ASC' : 'DESC'}`;
+const orderBy = ({ index, direction }) => {
+    const orderByVariable = `${sortIndices[index]}_${direction === SortByDirection.asc ? 'ASC' : 'DESC'}`;
+    // Additionally orderBy signature name to add more determinism to the order of the table rows
+    return sortIndices[index] !== 'NAME' ? [orderByVariable, 'NAME_ASC'] : orderByVariable;
+};
 
 const tableReducer = (state, action) => {
     switch (action.type) {
@@ -73,7 +77,7 @@ const SigTable = ({ refetchSigPageData }) => {
     const { data: sigTableData, loading: sigTableLoading, error: sigTableError, client } =
         useQuery(GET_SIGNATURE_TABLE, { variables: { ...tableVars, ...useReactiveVar(sigTableFilters) } });
     const mutationVars = {
-        variables: { input: { id: selectedSigs.map((sig) => sig.id) } },
+        variables: { input: { id: selectedSigs.map(sig => sig.id) } },
         onCompleted: () => {
             setShowTable(false);  // don't display the sig table rows whilst we are refetching the data
             client.resetStore();  // clear the query cache so we must refetch all new data
@@ -96,22 +100,37 @@ const SigTable = ({ refetchSigPageData }) => {
         items: { hasMatch: 'true', isDisabled: ['false'] },
         condition: { hasMatch: true, isDisabled: false }
     };
+
+    const updateSelectedSigs = ((selectedRows, selected) => {
+        // This function handles adding/removing sigs to/from the selectedSigs when rows are selected/unselected
+        const rowSigIds = selectedRows.map(row => row.sigData.id);
+        // remove sigs from the list when unselecting, but also prevents duplicate selectedSigs when adding
+        const filteredSigs = selectedSigs.filter(sig => !rowSigIds.includes(sig.id));
+        if (selected) {
+            // add the new selected sigs to the existing list of selectedSigs
+            return [...filteredSigs, ...selectedRows.map(sig =>
+                ({ id: sig.sigData.id, name: sig.sigData.name, isDisabled: sig.sigData.isDisabled }))];
+        } else {
+            return filteredSigs;
+        }
+    });
+
     const onSelect = (event, selected, rowKey) => {
         let selectedRows = [...rows];
+        let updatedSelectedSigs;
         if (rowKey === -1) {
             // All the rows were selected
             // However rows are actually in groups of 2 - row 1: rule match details, row 2: rule description (hidden by default),
             // So only set the first row in each group to selected (not the hidden row too)
             selectedRows = selectedRows.map((item, key) => key % 2 === 0 ? { ... item, selected } : { ...item });
+            updatedSelectedSigs = updateSelectedSigs(selectedRows.filter((item, key) => key % 2 === 0), selected);
         } else {
             selectedRows[rowKey] = { ...selectedRows[rowKey], selected };
+            updatedSelectedSigs = updateSelectedSigs([selectedRows[rowKey]], selected);
         }
 
-        // get a list of selected signature ids, which will be sent in the enable/disable rule mutation to the API
-        const selectedSigs = selectedRows.filter(row => row.selected).map(sig =>
-            ({ id: sig.sigData.id, name: sig.sigData.name, isDisabled: sig.sigData.isDisabled }));
         stateSet({ type: 'setRows', payload: selectedRows });
-        stateSet({ type: 'setSelectedSigs', payload: selectedSigs });
+        stateSet({ type: 'setSelectedSigs', payload: updatedSelectedSigs });
     };
 
     const onCollapse = (e, rowKey, isOpen) => {
@@ -300,6 +319,13 @@ const SigTable = ({ refetchSigPageData }) => {
     useEffect(() => {
         sigTableFilters(sigTableFiltersInitialState);
     }, []);
+
+    useEffect(() => {
+        // A hack to reset the SigTable page offset to the first page whenever the filters change
+        // This is because clicking on the StatusCard links doesn't refresh the pagination start page in the SigTable
+        // There may be a better way to handle this, but this is all I could come up with
+        stateSet({ type: 'setTableVars', payload: { offset: 0 } });
+    }, [sigTableFilters().condition]);
 
     useEffect(() => {
         const selectedSigIds = selectedSigs.map(sig => sig.id);


### PR DESCRIPTION
- Resets SigTable pagination whenever the filters change
- Correctly sets selectedSigs when SigTable rows are selected/unselected
- Apply secondary orderBy variable of NAME_ASC to table rows to add more determinism to their order