### PR TITLE
feat(RHINENG-2253): Add link to documentation in StatusCard

### DIFF
--- a/locales/translations.json
+++ b/locales/translations.json
@@ -43,6 +43,7 @@
   "lastSeen": "Last seen",
   "lastStatus": "Last status",
   "lastmatch": "Last match",
+  "learnMore": "Learn more",
   "malwareDetection": "Malware detection",
   "malwareDetectionSignatures": "Malware detection signatures",
   "malwareDetectionSigs": "Malware detection signatures",

--- a/src/Components/Common.js
+++ b/src/Components/Common.js
@@ -7,6 +7,7 @@ import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 import React from 'react';
 import propTypes from 'prop-types';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 const link = (desc, url = '#') => <Button isInline component='a' variant='link' href={url}>{desc}</Button>;
 
@@ -52,4 +53,16 @@ const RBACPermissions = {
     write: ['malware-detection:*:*']
 };
 
-export { link, gqlProps, isBeta, totalMatchesTitle, expandMatchMetadata, capitalize, strong, RBACPermissions };
+// eslint-disable-next-line max-len
+const documentationURL = 'https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/assessing_and_reporting_malware_signatures_on_rhel_systems/index';
+// eslint-disable-next-line react/prop-types
+const DocumentationLink = ({ children }) => (
+    <a href={documentationURL} target="__blank" rel="noopener noreferrer">
+        {children} <ExternalLinkAltIcon />
+    </a>
+);
+
+export {
+    link, gqlProps, isBeta, totalMatchesTitle, expandMatchMetadata, capitalize, strong, RBACPermissions,
+    documentationURL, DocumentationLink
+};

--- a/src/Components/SharedComponents/EmptyAccount.js
+++ b/src/Components/SharedComponents/EmptyAccount.js
@@ -10,6 +10,7 @@ import WrenchIcon from '@patternfly/react-icons/dist/esm/icons/wrench-icon';
 import { useIntl } from 'react-intl';
 import messages from '../../Messages';
 import propTypes from 'prop-types';
+import { documentationURL } from '../Common';
 
 const EmptyAccount = ({ message, className }) => {
     const intl = useIntl();
@@ -25,8 +26,7 @@ const EmptyAccount = ({ message, className }) => {
             <Button
                 variant="primary"
                 component="a"
-                // eslint-disable-next-line max-len
-                href={'https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/assessing_and_reporting_malware_signatures_on_rhel_systems'}
+                href={documentationURL}
                 target="_blank" >
                 {intl.formatMessage(messages.emptyAccountButton)}
             </Button>

--- a/src/Components/StatusCard/StatusCard.js
+++ b/src/Components/StatusCard/StatusCard.js
@@ -10,7 +10,7 @@ import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclam
 import Loading from '../../Components/Loading/Loading';
 import MessageState from '../MessageState/MessageState';
 import React from 'react';
-import { gqlProps } from '../Common';
+import { DocumentationLink, gqlProps } from '../Common';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
 import EmptyAccount from '../SharedComponents/EmptyAccount';
@@ -55,6 +55,7 @@ const StatusCard = ({ data: sigStatsData, loading: sigStatsLoading, noSigData })
                 {sigStatsData?.hostScans?.nodes[0]
                     ? <DateFormat date={new Date(sigStatsData?.hostScans?.nodes[0].createdAt)} type='onlyDate' /> :
                     intl.formatMessage(messages.noAnalysisRun)}
+                <p className='pf-u-pt-sm'><DocumentationLink>{intl.formatMessage(messages.learnMore)}</DocumentationLink></p>
             </MessageState>
         </GridItem>
     );

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -452,6 +452,11 @@ export default defineMessages({
         description: 'empty account card button',
         defaultMessage: 'Access installation guide'
     },
+    learnMore: {
+        id: 'learnMore',
+        description: 'Learn more link to malware documentation',
+        defaultMessage: 'Learn more'
+    },
     error: {
         id: 'error',
         description: 'Error',

--- a/src/Routes/Signatures/Signatures.js
+++ b/src/Routes/Signatures/Signatures.js
@@ -1,7 +1,7 @@
 import { GET_SIGNATURE_PAGE, GET_TIME_SERIES_STATS } from '../../operations/queries';
 import { Alert, Grid, GridItem, Split, SplitItem } from '@patternfly/react-core';
 import React, { Suspense, lazy, useEffect } from 'react';
-import { OutlinedQuestionCircleIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Popover } from '@patternfly/react-core';
 import Loading from '../../Components/Loading/Loading';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
@@ -11,6 +11,7 @@ import { useIntl } from 'react-intl';
 import { useQuery } from '@apollo/client';
 import { hasMalware } from '../../store/cache';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import { DocumentationLink } from '../../Components/Common';
 
 const SigTable = lazy(() => import(/* webpackChunkName: 'SigTable' */ '../../Components/SigTable/SigTable'));
 const StatusCard = lazy(() => import(/* webpackChunkName: 'StatusCard' */ '../../Components/StatusCard/StatusCard'));
@@ -41,14 +42,9 @@ const Signatures = () => {
                         bodyContent={(<Grid hasGutter>
                             <GridItem>{intl.formatMessage(messages.headerPopoverBody1)}</GridItem>
                         </Grid>)}
-                        footerContent={
-                            <a
-                                // eslint-disable-next-line max-len
-                                href={'https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/assessing_and_reporting_malware_signatures_on_rhel_systems'}
-                                target="__blank" rel="noopener noreferrer">
-                                {intl.formatMessage(messages.headerPopoverFooter)} <ExternalLinkAltIcon />
-                            </a>
-                        }
+                        footerContent={(<DocumentationLink>
+                            {intl.formatMessage(messages.headerPopoverFooter)}
+                        </DocumentationLink>)}
                     >
                         <PageHeaderTitle
                             title={


### PR DESCRIPTION
Adds a link to the documentation in the StatusCard component.  The link appears whether or not there was malware found, as per the screenshots:

![Screenshot from 2023-10-13 10-23-17](https://github.com/RedHatInsights/malware-detection-frontend/assets/4008744/faed9bfa-fa21-4dec-a464-f77497079eb4)
![Screenshot from 2023-10-13 10-26-05](https://github.com/RedHatInsights/malware-detection-frontend/assets/4008744/fb3799e5-953e-4f81-9a04-6b97ff7c001c)
