### PR TITLE
feat(RHINENG-2184): Add group filter and chips to SigDetailsPage

### DIFF
--- a/src/Components/SigDetailsTable/SigDetailsTable.js
+++ b/src/Components/SigDetailsTable/SigDetailsTable.js
@@ -16,7 +16,7 @@ import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle
 import CodeEditor from '../CodeEditor/CodeEditor';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { expandMatchMetadata } from '../Common';
-import { GET_SIGNATURE_DETAILS_TABLE } from '../../operations/queries';
+import { GET_SIGNATURE_DETAILS_TABLE, GET_SIGNATURE_DETAILS_TABLE_GROUPS } from '../../operations/queries';
 import MessageState from '../MessageState/MessageState';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
 import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
@@ -27,6 +27,7 @@ import { useQuery } from '@apollo/client';
 import EmptyAccount from '../SharedComponents/EmptyAccount';
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 import { SkeletonTable } from '@redhat-cloud-services/frontend-components/SkeletonTable';
+import { isEmpty, uniqWith } from 'lodash';
 
 const sortIndices = { 1: 'DISPLAY_NAME', 2: 'GROUPS', 3: 'OS_VERSION', 4: 'LAST_SCAN_DATE', 5: 'MATCH_COUNT' };
 const orderBy = ({ index, direction }) => `${sortIndices[index]}_${direction === SortByDirection.asc ? 'ASC' : 'DESC'}`;
@@ -39,6 +40,8 @@ const tableReducer = (state, action) => {
             return { ...state, sortBy: action.payload, tableVars: { ...state.tableVars, ...action.tableVars } };
         case 'setRows':
             return { ...state, rows: action.payload };
+        case 'setGroups':
+            return { ...state, groups: action.payload };
     }
 
     return state;
@@ -52,19 +55,23 @@ const SigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
             offset: 0,
             orderBy: 'LAST_SCAN_DATE_DESC',
             displayName: '',
+            condition: {},
             ruleName
         },
         sortBy: {
             index: 4,
             direction: SortByDirection.desc
         },
-        rows: []
+        rows: [],
+        groups: []
     };
-    const [{ tableVars, sortBy, rows }, stateSet] = useReducer(tableReducer, {
+    const [{ tableVars, sortBy, rows, groups }, stateSet] = useReducer(tableReducer, {
         ...initialState
     });
     const { data, loading, error } =
         useQuery(GET_SIGNATURE_DETAILS_TABLE, { variables: tableVars });
+    const { data: groupData } =
+        useQuery(GET_SIGNATURE_DETAILS_TABLE_GROUPS, { variables: { ruleName } });
     const columns = [
         { title: intl.formatMessage(messages.name), cellFormatters: [expandable], transforms: [sortable, cellWidth(45)] },
         { title: intl.formatMessage(messages.group), transforms: [sortable, cellWidth(15)] },
@@ -90,6 +97,20 @@ const SigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
             onChange: (e, value) => stateSet({ type: 'setTableVars', payload: { displayName: value, offset: 0 } }),
             value: tableVars.displayName,
             placeholder: intl.formatMessage(messages.filterBy, { field: intl.formatMessage(messages.name).toLowerCase() })
+        }
+    }, {
+        label: intl.formatMessage(messages.group).toLowerCase(),
+        type: 'checkbox',
+        filterValues: {
+            key: 'group-filter',
+            onChange: (e, value) => {
+                // Sets the group condition used in the GET_SIGNATURE_DETAILS_TABLE query
+                const condition = isEmpty(value) ? {} : { groups: value.map(item => JSON.parse(item)) };
+                stateSet({ type: 'setTableVars', payload: { condition }, offset: 0 });
+            },
+            items: groups,
+            value: tableVars.condition?.groups ? tableVars.condition.groups.map(group => JSON.stringify(group)) : [],
+            placeholder: intl.formatMessage(messages.filterBy, { field: intl.formatMessage(messages.group).toLowerCase() })
         }
     }];
 
@@ -143,6 +164,23 @@ ${host.matches.length > 1 && key !== host.matches.length - 1 ? `~~~~~~~~~~~~~~~~
         stateSet({ type: 'setRows', payload: rowBuilder(data?.rulesList[0]?.affectedHostsList) });
     }, [intl, data]);
 
+    useEffect(() => {
+        // populates the Group filter list
+        const getGroupList = groupData => {
+            return groupData?.filter(host => !isEmpty(host.groups)).map(host => {
+                const group = host.groups[0];
+                return {
+                    label: group.name,
+                    value: JSON.stringify({ id: group.id, name: group.name })
+                };
+            });
+        };
+
+        let groupsList = getGroupList(groupData?.rulesList[0]?.affectedHostsList) || [];
+        groupsList = uniqWith(groupsList, (group1, group2) => group1.label === group2.label);
+        stateSet({ type: 'setGroups', payload: groupsList });
+    }, [groupData]);
+
     const NoResultsMatch = (
         <MessageState className='pf-c-card' icon={SearchIcon} variant='large' title={intl.formatMessage(messages.noResults)}
             text={intl.formatMessage(messages.noResultsMatch)} />
@@ -162,6 +200,41 @@ ${host.matches.length > 1 && key !== host.matches.length - 1 ? `~~~~~~~~~~~~~~~~
         <MessageState className='pf-c-card' variant='large' title='Error' text='error' />
     );
 
+    const buildFilterChips = () => {
+        const chips = [];
+        tableVars?.displayName &&
+            chips.push({
+                category: intl.formatMessage(messages.name), value: 'name',
+                chips: [{ name: tableVars?.displayName, value: tableVars?.displayName }]
+            });
+        !isEmpty(tableVars?.condition) &&
+            chips.push({
+                category: intl.formatMessage(messages.group), value: 'groups',
+                chips: tableVars.condition.groups.map(group => ({ name: group.name, value: group.name }))
+            });
+        return chips;
+    };
+
+    const activeFiltersConfig = {
+        deleteTitle: intl.formatMessage(messages.resetFilters),
+        filters: buildFilterChips(),
+        showDeleteButton: tableVars?.displayName !== '' || !isEmpty(tableVars?.condition),
+        onDelete: (event, itemsToRemove, isAll) => {
+            if (isAll) {
+                stateSet({ type: 'setTableVars', payload: { displayName: '', condition: {}, offset: 0 } });
+            } else {
+                itemsToRemove.map((item) => {
+                    item.value === 'name' && stateSet({ type: 'setTableVars', payload: { displayName: '' } });
+                    if (item.value === 'groups') {
+                        const groups = tableVars.condition.groups.filter(group => group.name !== item.chips[0].name);
+                        const payload = groups.length ? { condition: { groups } } : { condition: {} };
+                        stateSet({ type: 'setTableVars', payload });
+                    }
+                });
+            }
+        }
+    };
+
     return <React.Fragment>
         <PrimaryToolbar
             pagination={{
@@ -173,6 +246,7 @@ ${host.matches.length > 1 && key !== host.matches.length - 1 ? `~~~~~~~~~~~~~~~~
                 isCompact: true
             }}
             filterConfig={{ items: filterConfigItems }}
+            activeFiltersConfig={activeFiltersConfig}
         />
         {loading
             ? <SkeletonTable

--- a/src/operations/queries.js
+++ b/src/operations/queries.js
@@ -65,9 +65,9 @@ export const GET_MALWARE_COUNT = gql`query QuerySigPage {
 }`;
 
 export const GET_SIGNATURE_DETAILS_TABLE = gql`query QuerySigPage($offset: Int = 0, $limit: Int = 10, $orderBy: [HostWithMatchesOrderBy!],
-$ruleName: String, $displayName: String)  {
+$ruleName: String, $displayName: String, $condition: HostWithMatchCondition)  {
   rulesList(condition: {name: $ruleName})  {
-    affectedHostsList (offset: $offset, first: $limit, orderBy: $orderBy, displayName: $displayName) {
+    affectedHostsList (offset: $offset, first: $limit, orderBy: $orderBy, displayName: $displayName, condition: $condition) {
       id
       displayName
       groups
@@ -87,8 +87,16 @@ $ruleName: String, $displayName: String)  {
         metadata
       }
     }
-    affectedHosts(offset: $offset, first: $limit, orderBy: $orderBy, displayName: $displayName) {
+    affectedHosts(offset: $offset, first: $limit, orderBy: $orderBy, displayName: $displayName, condition: $condition) {
       totalCount
+    }
+  }
+}`;
+
+export const GET_SIGNATURE_DETAILS_TABLE_GROUPS = gql`query QuerySigPageGroups($ruleName: String)  {
+  rulesList(condition: {name: $ruleName})  {
+    affectedHostsList (orderBy: GROUPS_ASC){
+      groups
     }
   }
 }`;


### PR DESCRIPTION
Before this PR, you could only filter the SignatureDetails page by name, and there were no filter chips:

![Screenshot from 2023-10-18 17-36-55](https://github.com/RedHatInsights/malware-detection-frontend/assets/4008744/865a1834-cd85-4698-8dc9-446ba6ee890b)
![Screenshot from 2023-10-18 17-36-45](https://github.com/RedHatInsights/malware-detection-frontend/assets/4008744/ddc63885-7f04-4603-ba11-b36bfa8f48a4)


With this PR, you can now also filter by host group name, and there are filter chips for both name and group:

![Screenshot from 2023-10-18 17-31-21](https://github.com/RedHatInsights/malware-detection-frontend/assets/4008744/409f604c-3c18-4498-8f96-1761768cc8b7)
![Screenshot from 2023-10-18 17-31-31](https://github.com/RedHatInsights/malware-detection-frontend/assets/4008744/f27018f1-a582-4deb-88c8-676fc6415596)
![Screenshot from 2023-10-18 17-32-06](https://github.com/RedHatInsights/malware-detection-frontend/assets/4008744/e8b125b3-e029-498c-9097-b648452f54c3)
