### PR TITLE
fix(RHINENG-2708): Temporarily fixes broken OS filter in prod

### DIFF
--- a/src/Components/SysTable/hooks.js
+++ b/src/Components/SysTable/hooks.js
@@ -1,11 +1,17 @@
 import { useApolloClient } from '@apollo/client';
-import isEmpty from 'lodash/isEmpty';
+import { isEmpty, isString } from 'lodash';
 
 export const buildApiFilters = (filters = {}) => {
     const { tagFilters, ...otherFilters } = filters;
     // remove hostGroupFilter/osFilter if they are [], otherwise no results are returned from the API
     isEmpty(otherFilters.hostGroupFilter) && delete otherFilters.hostGroupFilter;
-    isEmpty(otherFilters.osFilter) && delete otherFilters.osFilter;
+    if (isEmpty(otherFilters.osFilter)) {
+        delete otherFilters.osFilter;
+    } else {
+        // TODO: temporary workaround whereby osFilter may be a string (in stage) or an object (in prod)
+        otherFilters.osFilter = otherFilters.osFilter.map(os => isString(os) ? os : os.value);
+    }
+
     const tagsApiFilter = tagFilters
         ? {
             tags: tagFilters.flatMap((tagFilter) =>


### PR DESCRIPTION
On stage, the osFilter is an array of strings and it works with our current implementation:
![Screenshot from 2023-10-24 17-00-30](https://github.com/RedHatInsights/malware-detection-frontend/assets/4008744/a0082a6e-5917-4480-a712-e9e308785d98)


On prod, the osFilter is an array of objects and breaks our current implementation:
![Screenshot from 2023-10-24 17-00-36](https://github.com/RedHatInsights/malware-detection-frontend/assets/4008744/99e0b5bf-1e25-48c8-b33f-23782ab1826d)

This PR allows our SysTable component to work with with either an array of strings or objects.  This doesn't feel like the right way to fix this, but its just a temporary workaround until we can work out a more permanent solution (which may require changes to the backend).