### PR TITLE
Set filename when downloading signature

### DIFF
--- a/src/Components/CodeEditor/CodeEditor.js
+++ b/src/Components/CodeEditor/CodeEditor.js
@@ -5,12 +5,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
+import { formatDate } from '../SigTable/helper';
 
 const CodeEditor = ({ code, language, isReadOnly, isDownloadEnabled, isCopyEnabled, height = '400px' }) => {
     const intl = useIntl();
 
     return <PfCodeEditor
         isDownloadEnabled={isDownloadEnabled}
+        downloadFileName={`malware-detection_signature--${formatDate(Date.now(), true)}`}
         isCopyEnabled={isCopyEnabled}
         isReadOnly={isReadOnly}
         isLanguageLabelVisible={language}

--- a/src/Components/CodeEditor/CodeEditor.js
+++ b/src/Components/CodeEditor/CodeEditor.js
@@ -12,7 +12,7 @@ const CodeEditor = ({ code, language, isReadOnly, isDownloadEnabled, isCopyEnabl
 
     return <PfCodeEditor
         isDownloadEnabled={isDownloadEnabled}
-        downloadFileName={`malware-detection_signature--${formatDate(Date.now(), true)}`}
+        downloadFileName={`malware-detection_signature--${formatDate(Date.now())}`}
         isCopyEnabled={isCopyEnabled}
         isReadOnly={isReadOnly}
         isLanguageLabelVisible={language}

--- a/src/Components/SigTable/helper.js
+++ b/src/Components/SigTable/helper.js
@@ -5,3 +5,21 @@ export const isFilterInDefaultState = (currentFilters) => {
 
     return isEqual(defaultfilter, currentFilters);
 };
+
+export function formatDate(date = new Date()) {
+    const pad = (number) => `${`${number}`.length === 1 ? '0' : ''}${number}`;
+    const toFormat = new Date(date);
+
+    if (toFormat instanceof Date && !isNaN(toFormat)) {
+        const year = toFormat.getFullYear();
+        const month = toFormat.getMonth() + 1; // month is zero indexed
+        const day = toFormat.getDate();
+        const hour = toFormat.getUTCHours();
+        const minute = toFormat.getUTCMinutes();
+        const second = toFormat.getUTCSeconds();
+
+        return `${year}-${pad(month)}-${pad(day)}_${pad(hour)}-${pad(minute)}-${pad(second)}-UTC`;
+    }
+
+    return toFormat;
+}


### PR DESCRIPTION
Part of: https://issues.redhat.com/browse/RHINENG-1217
> System detail page and Signature detail page: Expandable section: Downloaded file has some timestamp in the name, it would be more useful if it was named after the system and signature

Fixed according to the UX file naming conventions: https://docs.google.com/document/d/1-SO02nTHuQE9FLz48uCrHnnyDs_bYKzfcmC2ztQAiWs/edit

Previous filename: `1698434121672.txt`
Updated filename: `malware-detection_signature--2023-10-27_19-17-38-UTC.txt`