### PR TITLE
Update Status Card loading state

### DIFF
--- a/src/Components/StatusCard/StatusCard.js
+++ b/src/Components/StatusCard/StatusCard.js
@@ -62,15 +62,19 @@ const StatusCard = ({ data: sigStatsData, loading: sigStatsLoading, noSigData })
 
     return <Card className='ins-l-card'>
         <CardBody>
-            <Grid>
-                {
-                    sigStatsLoading ? <Loading /> : (sigStatsData.hosts?.totalCount === 0 && EmptyAccountState || FilterResultState)
-                }
-                {!noSigData && <React.Fragment>
-                    <GridItem span={1}
-                        className='pf-c-divider pf-m-vertical pf-m-inset-md pf-m-inset-none-on-md pf-m-inset-sm-on-lg pf-m-inset-xs-on-xl' />
-                    {sigStatsLoading ? <Loading />
-                        : <GridItem className='ins-l-sigStatCard' span={3}>
+            {sigStatsLoading
+                ? <Loading />
+                : <Grid>
+                    {
+                        sigStatsData.hosts?.totalCount === 0 && EmptyAccountState || FilterResultState
+                    }
+                    {!noSigData && <React.Fragment>
+                        <GridItem
+                            span={1}
+                            className='pf-c-divider pf-m-vertical pf-m-inset-md pf-m-inset-none-on-md pf-m-inset-sm-on-lg pf-m-inset-xs-on-xl'
+                        />
+
+                        <GridItem className='ins-l-sigStatCard' span={3}>
                             <GridItem className='ins-l-sigStat' span={12}>
                                 <strong>{matchedCount}</strong>
                                 <br />
@@ -93,9 +97,9 @@ const StatusCard = ({ data: sigStatsData, loading: sigStatsLoading, noSigData })
                                 </a>
                             </GridItem>
                         </GridItem>
-                    }
-                </React.Fragment>}
-            </Grid>
+                    </React.Fragment>}
+                </Grid>
+            }
         </CardBody>
     </Card >;
 };

--- a/src/Routes/Signatures/Signatures.js
+++ b/src/Routes/Signatures/Signatures.js
@@ -74,14 +74,19 @@ const Signatures = () => {
         <Main className='pf-u-pt-sm'>
             <Grid hasGutter>
                 <GridItem lg={6} md={12}>
-                    <Suspense fallback={<Loading />}><StatusCard {...sigPageData} /></Suspense>
+                    <Suspense fallback={<Loading />}>
+                        <StatusCard {...sigPageData} />
+                    </Suspense>
                 </GridItem>
                 <GridItem lg={6} md={12}>
-                    <Suspense fallback={<Loading />}><ChartCard sysStats={sigPageData} chartStats={chartCmpData} /></Suspense>
+                    <Suspense fallback={<Loading />}>
+                        <ChartCard sysStats={sigPageData} chartStats={chartCmpData} />
+                    </Suspense>
                 </GridItem>
                 <GridItem span={12}>
                     <Suspense fallback={<Loading />}>
-                        <SigTable refetchSigPageData={refetch}/></Suspense>
+                        <SigTable refetchSigPageData={refetch}/>
+                    </Suspense>
                 </GridItem>
             </Grid>
         </Main>


### PR DESCRIPTION
Part of: https://issues.redhat.com/browse/RHINENG-1217
> Signatures page: Status card should have only one loader each, but has two

### Before:
![Screenshot from 2023-10-27 22-17-31](https://github.com/RedHatInsights/malware-detection-frontend/assets/8426204/b085dbf2-4f47-4b89-a569-535045f6f039)

### After:
![Screenshot from 2023-10-27 22-17-03](https://github.com/RedHatInsights/malware-detection-frontend/assets/8426204/ce513e12-07c0-42a3-bada-09caea3cd40f)

### After loading:
![Screenshot from 2023-10-27 22-17-41](https://github.com/RedHatInsights/malware-detection-frontend/assets/8426204/ea3eef4e-f609-4992-933c-ddedd1e26a45)
