### PR TITLE
fix(RHINENG-2647): Filter affectedHostsList by multiple groups

### DIFF
--- a/src/Components/SigDetailsTable/SigDetailsTable.js
+++ b/src/Components/SigDetailsTable/SigDetailsTable.js
@@ -31,7 +31,7 @@ import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLin
 import { SkeletonTable } from '@redhat-cloud-services/frontend-components/SkeletonTable';
 import { isEmpty, uniqWith } from 'lodash';
 
-const sortIndices = { 1: 'DISPLAY_NAME', 2: 'GROUPS', 3: 'OS_VERSION', 4: 'LAST_SCAN_DATE', 5: 'MATCH_COUNT' };
+const sortIndices = { 1: 'DISPLAY_NAME', 2: 'GROUP_NAME', 3: 'OS_VERSION', 4: 'LAST_SCAN_DATE', 5: 'MATCH_COUNT' };
 const orderBy = ({ index, direction }) => `${sortIndices[index]}_${direction === SortByDirection.asc ? 'ASC' : 'DESC'}`;
 
 const tableReducer = (state, action) => {
@@ -57,7 +57,7 @@ const SigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
             offset: 0,
             orderBy: 'LAST_SCAN_DATE_DESC',
             displayName: '',
-            condition: {},
+            hostGroupFilter: undefined,
             ruleName
         },
         sortBy: {
@@ -106,14 +106,13 @@ const SigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
         filterValues: {
             key: 'group-filter',
             onChange: (e, value) => {
-                // Sets the group condition used in the GET_SIGNATURE_DETAILS_TABLE query
-                const condition = isEmpty(value) ? {} : { groups: value.map(item => JSON.parse(item)) };
-                stateSet({ type: 'setTableVars', payload: { condition }, offset: 0 });
+                // Populates hostGroupFilter used in the GET_SIGNATURE_DETAILS_TABLE query
+                stateSet({ type: 'setTableVars', payload: { hostGroupFilter: value }, offset: 0 });
             },
             items: groupsLoading ? []  // display an empty box whilst the groups are loading
                 : isEmpty(groups) ? [{ isDisabled: true, label: intl.formatMessage(messages.noGroups) }]  // message if no groups
                     : groups,
-            value: tableVars.condition?.groups ? tableVars.condition.groups.map(group => JSON.stringify(group)) : [],
+            value: tableVars.hostGroupFilter,
             placeholder: intl.formatMessage(messages.filterBy, { field: intl.formatMessage(messages.group).toLowerCase() })
         }
     }];
@@ -169,19 +168,15 @@ ${host.matches.length > 1 && key !== host.matches.length - 1 ? `~~~~~~~~~~~~~~~~
     }, [intl, data]);
 
     useEffect(() => {
-        // populates the Group filter list
+        // populates the Group name filter dropdown
         const getGroupList = groupsData => {
-            return groupsData?.filter(host => !isEmpty(host.groups)).map(host => {
-                const group = host.groups[0];
-                return {
-                    label: group.name,
-                    value: JSON.stringify({ id: group.id, name: group.name })
-                };
-            });
+            return groupsData?.filter(host => !isEmpty(host.groups)).map(host => (
+                { label: host.groups[0].name, value: host.groups[0].name })
+            );
         };
 
         let groupsList = getGroupList(groupsData?.rulesList[0]?.affectedHostsList) || [];
-        groupsList = uniqWith(groupsList, (group1, group2) => group1.label === group2.label);
+        groupsList = uniqWith(groupsList, (group1, group2) => group1.label === group2.label); // remove duplicate group names
         stateSet({ type: 'setGroups', payload: groupsList });
     }, [groupsData]);
 
@@ -211,10 +206,10 @@ ${host.matches.length > 1 && key !== host.matches.length - 1 ? `~~~~~~~~~~~~~~~~
                 category: intl.formatMessage(messages.name), value: 'name',
                 chips: [{ name: tableVars?.displayName, value: tableVars?.displayName }]
             });
-        !isEmpty(tableVars?.condition) &&
+        tableVars?.hostGroupFilter &&
             chips.push({
                 category: intl.formatMessage(messages.group), value: 'groups',
-                chips: tableVars.condition.groups.map(group => ({ name: group.name, value: group.name }))
+                chips: tableVars.hostGroupFilter.map(group => ({ name: group, value: group }))
             });
         return chips;
     };
@@ -222,16 +217,16 @@ ${host.matches.length > 1 && key !== host.matches.length - 1 ? `~~~~~~~~~~~~~~~~
     const activeFiltersConfig = {
         deleteTitle: intl.formatMessage(messages.resetFilters),
         filters: buildFilterChips(),
-        showDeleteButton: tableVars?.displayName !== '' || !isEmpty(tableVars?.condition),
+        showDeleteButton: tableVars?.displayName !== '' || tableVars?.hostGroupFilter !== undefined,
         onDelete: (event, itemsToRemove, isAll) => {
             if (isAll) {
-                stateSet({ type: 'setTableVars', payload: { displayName: '', condition: {}, offset: 0 } });
+                stateSet({ type: 'setTableVars', payload: { displayName: '', hostGroupFilter: undefined, offset: 0 } });
             } else {
                 itemsToRemove.map((item) => {
                     item.value === 'name' && stateSet({ type: 'setTableVars', payload: { displayName: '' } });
                     if (item.value === 'groups') {
-                        const groups = tableVars.condition.groups.filter(group => group.name !== item.chips[0].name);
-                        const payload = groups.length ? { condition: { groups } } : { condition: {} };
+                        const groupChips = tableVars.hostGroupFilter.filter(group => group !== item.chips[0].name);
+                        const payload = { hostGroupFilter: groupChips.length ? groupChips : undefined, offset: 0 };
                         stateSet({ type: 'setTableVars', payload });
                     }
                 });

--- a/src/Components/SysTable/hooks.js
+++ b/src/Components/SysTable/hooks.js
@@ -8,7 +8,7 @@ export const buildApiFilters = (filters = {}) => {
     if (isEmpty(otherFilters.osFilter)) {
         delete otherFilters.osFilter;
     } else {
-        // TODO: temporary workaround whereby osFilter may be a string (in stage) or an object (in prod)
+        // Handle osFilter either as a string (the old way) or an object (the newer implementation)
         otherFilters.osFilter = otherFilters.osFilter.map(os => isString(os) ? os : os.value);
     }
 

--- a/src/operations/queries.js
+++ b/src/operations/queries.js
@@ -64,10 +64,16 @@ export const GET_MALWARE_COUNT = gql`query QuerySigPage {
   }
 }`;
 
-export const GET_SIGNATURE_DETAILS_TABLE = gql`query QuerySigPage($offset: Int = 0, $limit: Int = 10, $orderBy: [HostWithMatchesOrderBy!],
-$ruleName: String, $displayName: String, $condition: HostWithMatchCondition)  {
-  rulesList(condition: {name: $ruleName})  {
-    affectedHostsList (offset: $offset, first: $limit, orderBy: $orderBy, displayName: $displayName, condition: $condition) {
+export const GET_SIGNATURE_DETAILS_TABLE = gql`query QuerySigPage($offset: Int = 0, $limit: Int = 10,
+  $orderBy: [HostWithMatchesOrderBy!], $ruleName: String, $displayName: String, $hostGroupFilter: [String]) {
+  rulesList(ruleName: $ruleName) {
+    affectedHostsList(
+      offset: $offset
+      first: $limit
+      orderBy: $orderBy
+      displayName: $displayName
+      groupName: $hostGroupFilter
+    ) {
       id
       displayName
       groups
@@ -87,15 +93,21 @@ $ruleName: String, $displayName: String, $condition: HostWithMatchCondition)  {
         metadata
       }
     }
-    affectedHosts(offset: $offset, first: $limit, orderBy: $orderBy, displayName: $displayName, condition: $condition) {
+    affectedHosts(
+      offset: $offset
+      first: $limit
+      orderBy: $orderBy
+      displayName: $displayName
+      groupName: $hostGroupFilter
+    ) {
       totalCount
     }
   }
 }`;
 
 export const GET_SIGNATURE_DETAILS_TABLE_GROUPS = gql`query QuerySigPageGroups($ruleName: String)  {
-  rulesList(condition: {name: $ruleName})  {
-    affectedHostsList (orderBy: GROUPS_ASC){
+  rulesList(ruleName: $ruleName)  {
+    affectedHostsList (orderBy: GROUP_NAME_ASC){
       groups
     }
   }


### PR DESCRIPTION
Before this PR, filtering the SigDetailsTable hosts by multiple groups returned no results (because the backend didn't support it):
![Screenshot from 2023-10-31 17-29-33](https://github.com/RedHatInsights/malware-detection-frontend/assets/4008744/5ea9ed6f-9dea-4123-9c3a-c7a21e600e02)


The backend has been recently updated and supports it now, so filtering SigDetailsTable hosts by multiple groups works.  This PR changes the GraphQL query / variables sent to the backend for filtering by multiple groups:
![Screenshot from 2023-10-31 17-31-10](https://github.com/RedHatInsights/malware-detection-frontend/assets/4008744/837c4819-908d-4447-93ac-3f0170b2e096)

