### PR TITLE
fix: Address the RootApp Sentry error in stage

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -8,7 +8,10 @@ const plugins = [fedModulePlugin({
         {
             'react-router-dom': { singleton: true, requiredVersion: '*' }
         }
-    ]
+    ],
+    exposes: {
+        './RootApp': resolve(__dirname, '../src/AppEntry')
+    }
 })];
 
 // Save 20kb of bundle size in prod

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -5,7 +5,7 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
 const { config: webpackConfig, plugins } = config({
     rootFolder: resolve(__dirname, '../'),
-    ...process.env.BETA === 'true' && { deployment: 'beta/apps' }
+    ...(process.env.BETA === 'true' && { deployment: 'beta/apps' })
 });
 plugins.push(...commonPlugins);
 


### PR DESCRIPTION
Not really sure it its going to fix the error, but I notice that malware doesn't have this config plugin option but other apps (eg Advisor, Inventory) seem to have it.