### PR TITLE
chore(RHINENG-9387): update page titles

### DIFF
--- a/src/Routes/Signatures/Details.js
+++ b/src/Routes/Signatures/Details.js
@@ -84,7 +84,7 @@ const Details = () => {
     );
 
     useEffect(() => {
-        chrome.updateDocumentTitle(`${sigName} - Signatures - Malware | Red Hat Insights`);
+        chrome.updateDocumentTitle(`${sigName} - Signatures - Malware | RHEL`);
     }, [chrome, sigName]);
 
     useEffect(() => {

--- a/src/Routes/Signatures/Details.js
+++ b/src/Routes/Signatures/Details.js
@@ -84,7 +84,7 @@ const Details = () => {
     );
 
     useEffect(() => {
-        chrome.updateDocumentTitle(`${sigName} - Signatures - Malware | RHEL`);
+        chrome.updateDocumentTitle(`${sigName} - Signatures - Malware`);
     }, [chrome, sigName]);
 
     useEffect(() => {

--- a/src/Routes/Signatures/Signatures.js
+++ b/src/Routes/Signatures/Signatures.js
@@ -24,7 +24,7 @@ const Signatures = () => {
     const chartCmpData = useQuery(GET_TIME_SERIES_STATS);
     const chrome = useChrome();
     useEffect(() => {
-        chrome.updateDocumentTitle(`Signatures - Malware | RHEL`);
+        chrome.updateDocumentTitle(`Signatures - Malware`);
     }, [chrome]);
 
     // set hasMalware to true if any enabled rules have matches (disabled rules don't count)

--- a/src/Routes/Signatures/Signatures.js
+++ b/src/Routes/Signatures/Signatures.js
@@ -24,7 +24,7 @@ const Signatures = () => {
     const chartCmpData = useQuery(GET_TIME_SERIES_STATS);
     const chrome = useChrome();
     useEffect(() => {
-        chrome.updateDocumentTitle(`Signatures - Malware | Red Hat Insights`);
+        chrome.updateDocumentTitle(`Signatures - Malware | RHEL`);
     }, [chrome]);
 
     // set hasMalware to true if any enabled rules have matches (disabled rules don't count)

--- a/src/Routes/Systems/Details.js
+++ b/src/Routes/Systems/Details.js
@@ -39,7 +39,7 @@ const Details = () => {
     const chrome = useChrome();
     //Need to wait for sysData to grab variable
     useEffect(() => {
-        sysData && chrome.updateDocumentTitle(`${sysData.displayName} - Systems - Malware | Red Hat Insights`);
+        sysData && chrome.updateDocumentTitle(`${sysData.displayName} - Systems - Malware | RHEL`);
     }, [chrome, sysData]);
     return <React.Fragment>
         <PageHeader>

--- a/src/Routes/Systems/Details.js
+++ b/src/Routes/Systems/Details.js
@@ -39,7 +39,7 @@ const Details = () => {
     const chrome = useChrome();
     //Need to wait for sysData to grab variable
     useEffect(() => {
-        sysData && chrome.updateDocumentTitle(`${sysData.displayName} - Systems - Malware | RHEL`);
+        sysData && chrome.updateDocumentTitle(`${sysData.displayName} - Systems - Malware`);
     }, [chrome, sysData]);
     return <React.Fragment>
         <PageHeader>

--- a/src/Routes/Systems/Systems.js
+++ b/src/Routes/Systems/Systems.js
@@ -22,7 +22,7 @@ const Systems = () => {
     const chartCmpData = useQuery(GET_TIME_SERIES_STATS);
     const chrome = useChrome();
     useEffect(() => {
-        chrome.updateDocumentTitle(`Systems - Malware | RHEL`);
+        chrome.updateDocumentTitle(`Systems - Malware`);
     }, [chrome]);
 
     return <React.Fragment>

--- a/src/Routes/Systems/Systems.js
+++ b/src/Routes/Systems/Systems.js
@@ -22,7 +22,7 @@ const Systems = () => {
     const chartCmpData = useQuery(GET_TIME_SERIES_STATS);
     const chrome = useChrome();
     useEffect(() => {
-        chrome.updateDocumentTitle(`Systems - Malware | Red Hat Insights`);
+        chrome.updateDocumentTitle(`Systems - Malware | RHEL`);
     }, [chrome]);
 
     return <React.Fragment>


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHINENG-9387

Updates page titles according to 'Current concept' column, single line treatment in this [sheet](https://docs.google.com/spreadsheets/d/1Uhwn6i9B383xUbnRQ2IWY3EZ6dihc-UfkHxnR_c7zXI/edit#gid=1001620868). I have removed the title suffix "Red Hat Insights". Now it will be added by chrome app: https://github.com/RedHatInsights/insights-chrome/commit/64ccf6a190136949911757171d4f2062d02c5235