### PR TITLE
chore: use focal dist and node 18 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ notifications:
   slack:
     rooms:
       - secure: juuizlfiQolXbqy4L2nfODB1K8xiSGvUrzsT3XeXIsQqX7yCYVvnRUssKLbqgLM9m85kgXJk1ef0qwjJoliNqGcrALTZLHPTkxWwTnV7tPEVS/4uQPSyy+DDHDwrTzCrF3qhCqyKJ6vB18z22qm3qLgStmNj4p1ZLznsdJR/u7U3spJ+WLL70QSNHCQy/5QjRDDiR3oqWdXjhVcUCeV+v/2CtfqK3dqYtzCL/b7z8lm/YbV6w1Rd8mwzTgLstbzjrvR/gq2IPALzzJTq1S8lXtV7ZtbYz4bjB8RNCRZFJrjBUH4CqD1oUskit4RRe+ilVs8qNQh0Tt3whsOdbJoRXJn2B/NVxppp2WGlODdsuMgfNh5iBocHKN3Qo4mONbstnHFG99Hr7L8GbUugJHEQlrZn1xRyO9ulyVp+hFp8/F088NNyhnd3+lERUPA5/4+HPQh6Ea+PyKq2TR41VoDGcRDBS4VY/6PfLEJzxEBjwRAAemfvtOFTUu2EocuAllPX1vMA4b1j7Wm+Bs7wft6nEcVdftVanfAgx4dNksnaS8zN9II8rdtBci2yXYJ6J+e+REDn/2IrHaUwr0N9BojYc0ePUElDcygW4Kk1oGklHp681j2zhi1Gt7rbuae1C9fD4QHnryx59uVH5NXqDsXI5EbwTJE3zvzRz9SzmyDqV5A=
+dist: focal
 node_js:
-- '16'
+- '18'
 install:
 - npm ci
 jobs:


### PR DESCRIPTION
use focal dist and node 18 in travis. It fixes the failing cypress tests in  https://github.com/RedHatInsights/malware-detection-frontend/pull/120