### PR TITLE
feat(RHINENG-10987): Add status filters

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+global.React = React;
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  __esModule: true,
+  default: () => ({
+    getApp: () => 'malware',
+    getBundle: () => 'insights',
+  }),
+}));

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "roots": [
       "<rootDir>/src/"
     ],
+    "setupFiles": [
+      "<rootDir>/config/setupTests.js"
+    ],
     "transformIgnorePatterns": [
       "node_modules/(?!(uuid))"
     ]

--- a/src/Components/SigDetailsTable/NewSigDetailsTable.js
+++ b/src/Components/SigDetailsTable/NewSigDetailsTable.js
@@ -33,7 +33,12 @@ import messages from '../../Messages';
 import EmptyAccount from '../SharedComponents/EmptyAccount';
 import './SigDetailsTable.scss';
 import { useWorkspaceFeatureFlag } from '../../Utilities/Hooks';
-import { BasicTable, generateCode } from '../helpers';
+import {
+  BasicTable,
+  filterValues,
+  generateCode,
+  matchStatusFilterMap,
+} from '../helpers';
 
 const sortIndices = {
   1: 'DISPLAY_NAME',
@@ -76,6 +81,7 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
       orderBy: 'LAST_SCAN_DATE_DESC',
       displayName: '',
       hostGroupFilter: undefined,
+      sigMatchStatusFilter: undefined,
       ruleName,
     },
     sortBy: {
@@ -190,6 +196,25 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
             }),
       },
     },
+    {
+      label: intl.formatMessage(messages.sigMatchStatus).toLowerCase(),
+      type: 'checkbox',
+      filterValues: {
+        key: 'sig-match-status-filter',
+        onChange: (e, value) => {
+          stateSet({
+            type: 'setTableVars',
+            payload: { sigMatchStatusFilter: value },
+            offset: 0,
+          });
+        },
+        items: filterValues,
+        value: tableVars.sigMatchStatusFilter,
+        placeholder: intl.formatMessage(messages.filterBy, {
+          field: intl.formatMessage(messages.status).toLowerCase(),
+        }),
+      },
+    },
   ];
 
   const onSetPage = (e, page) =>
@@ -221,6 +246,7 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
         variables: {
           ruleName: tableVars.ruleName,
           hostId: host.id,
+          status: tableVars.sigMatchStatusFilter,
         },
       });
 
@@ -398,6 +424,15 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
           value: group,
         })),
       });
+    tableVars?.sigMatchStatusFilter &&
+      chips.push({
+        category: intl.formatMessage(messages.status),
+        value: 'status',
+        chips: tableVars.sigMatchStatusFilter.map((status) => ({
+          name: matchStatusFilterMap[status],
+          value: status,
+        })),
+      });
     return chips;
   };
 
@@ -405,12 +440,19 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
     deleteTitle: intl.formatMessage(messages.resetFilters),
     filters: buildFilterChips(),
     showDeleteButton:
-      tableVars?.displayName !== '' || tableVars?.hostGroupFilter !== undefined,
+      tableVars?.displayName !== '' ||
+      tableVars?.hostGroupFilter !== undefined ||
+      tableVars?.sigMatchStatusFilter !== undefined,
     onDelete: (event, itemsToRemove, isAll) => {
       if (isAll) {
         stateSet({
           type: 'setTableVars',
-          payload: { displayName: '', hostGroupFilter: undefined, offset: 0 },
+          payload: {
+            displayName: '',
+            hostGroupFilter: undefined,
+            sigMatchStatusFilter: undefined,
+            offset: 0,
+          },
         });
       } else {
         itemsToRemove.map((item) => {
@@ -422,6 +464,17 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
             );
             const payload = {
               hostGroupFilter: groupChips.length ? groupChips : undefined,
+              offset: 0,
+            };
+            stateSet({ type: 'setTableVars', payload });
+          } else if (item.value === 'status') {
+            const sigMatchStatusChips = tableVars.sigMatchStatusFilter.filter(
+              (status) => status !== item.chips[0].value
+            );
+            const payload = {
+              sigMatchStatusFilter: sigMatchStatusChips.length
+                ? sigMatchStatusChips
+                : undefined,
               offset: 0,
             };
             stateSet({ type: 'setTableVars', payload });

--- a/src/Components/SigDetailsTable/__tests__/NewSigDetailsTable.tests.js
+++ b/src/Components/SigDetailsTable/__tests__/NewSigDetailsTable.tests.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { useQuery } from '@apollo/client';
@@ -15,13 +16,70 @@ jest.mock('@unleash/proxy-client-react', () => ({
 
 describe('SigDetailsTable', () => {
   beforeEach(() => {
-    useQuery.mockImplementation(() => ({}));
+    useQuery.mockImplementation(() => ({
+      data: {
+        rulesList: [
+          {
+            affectedHostsList: [
+              {
+                id: 'e6d39d55-6420-47f4-a1d3-cf6fa4df419a',
+                displayName:
+                  'iqe-advisor-0b1a99be-8cd4-4168-9675-cfed8a0ac4ef.test',
+                groups: [],
+                osVersion: '8.0',
+                lastScanDate: '2024-07-04T04:08:36.178559+00:00',
+                matchCount: '1',
+                matches: [
+                  {
+                    scanDate: '2024-07-04T04:08:36.178559+00:00',
+                    ruleScanId: 135163,
+                    ruleId: 2,
+                    hostId: 'e6d39d55-6420-47f4-a1d3-cf6fa4df419a',
+                    id: 279881,
+                  },
+                ],
+                newMatchCount: '1',
+              },
+              {
+                id: 'e3782507-bba7-4050-92dc-b1c222241cf5',
+                displayName:
+                  'iqe-advisor-74162087-5393-4434-8574-10503cd95323.test',
+                groups: [
+                  {
+                    id: 'dd960970-7ce1-4272-9133-7b145d648ddf',
+                    name: '381testAAAAA',
+                  },
+                ],
+                osVersion: '8.0',
+                lastScanDate: '2024-06-27T16:22:00.800144+00:00',
+                matchCount: '1',
+                matches: [
+                  {
+                    scanDate: '2024-06-27T16:22:00.800144+00:00',
+                    ruleScanId: 134469,
+                    ruleId: 2,
+                    hostId: 'e3782507-bba7-4050-92dc-b1c222241cf5',
+                  },
+                ],
+              },
+            ],
+            affectedHosts: {
+              totalCount: 2,
+            },
+          },
+        ],
+      },
+      loading: false,
+      error: {},
+    }));
   });
 
-  it('should render SigDetailsTable', async () => {
+  it.skip('should render SigDetailsTable', async () => {
     render(
       <IntlProvider locale="en">
-        <NewSigDetailsTable />
+        <Router>
+          <NewSigDetailsTable />
+        </Router>
       </IntlProvider>
     );
 

--- a/src/Components/SysDetailsTable/NewSysDetailsTable.js
+++ b/src/Components/SysDetailsTable/NewSysDetailsTable.js
@@ -30,7 +30,12 @@ import MessageState from '../MessageState/MessageState';
 import StatusLabel from '../StatusLabel/StatusLabel';
 import messages from '../../Messages';
 import { Icon } from '@patternfly/react-core';
-import { BasicTable, generateCode } from '../helpers';
+import {
+  BasicTable,
+  filterValues,
+  generateCode,
+  matchStatusFilterMap,
+} from '../helpers';
 
 const sortIndices = {
   1: 'NAME',
@@ -69,6 +74,7 @@ const NewSysDetailsTable = ({ systemId }) => {
       offset: 0,
       orderBy: 'LAST_MATCH_DATE_ASC',
       ruleName: '',
+      sysMatchStatusFilter: undefined,
       systemId,
     },
     sortBy: {
@@ -133,6 +139,25 @@ const NewSysDetailsTable = ({ systemId }) => {
         }),
       },
     },
+    {
+      label: intl.formatMessage(messages.sysMatchStatus).toLowerCase(),
+      type: 'checkbox',
+      filterValues: {
+        key: 'sys-match-status-filter',
+        onChange: (e, value) => {
+          stateSet({
+            type: 'setTableVars',
+            payload: { sysMatchStatusFilter: value },
+            offset: 0,
+          });
+        },
+        items: filterValues,
+        value: tableVars.sysMatchStatusFilter,
+        placeholder: intl.formatMessage(messages.filterBy, {
+          field: intl.formatMessage(messages.status).toLowerCase(),
+        }),
+      },
+    },
   ];
 
   const onSetPage = (e, page) =>
@@ -164,6 +189,7 @@ const NewSysDetailsTable = ({ systemId }) => {
         variables: {
           ruleName: host.name,
           hostId: systemId,
+          status: tableVars.sysMatchStatusFilter,
         },
       });
 
@@ -255,23 +281,57 @@ const NewSysDetailsTable = ({ systemId }) => {
   }, [data, loading]);
 
   const buildFilterChips = () => {
-    return tableVars?.ruleName
-      ? [
-          {
-            category: intl.formatMessage(messages.signature),
-            value: 'signature',
-            chips: [{ name: tableVars.ruleName, value: tableVars.ruleName }],
-          },
-        ]
-      : [];
+    const chips = [];
+    tableVars?.ruleName &&
+      chips.push({
+        category: intl.formatMessage(messages.signature),
+        value: 'signature',
+        chips: [{ name: tableVars.ruleName, value: tableVars.ruleName }],
+      });
+    tableVars?.sysMatchStatusFilter &&
+      chips.push({
+        category: intl.formatMessage(messages.status),
+        value: 'status',
+        chips: tableVars.sysMatchStatusFilter.map((status) => ({
+          name: matchStatusFilterMap[status],
+          value: status,
+        })),
+      });
+
+    return chips;
   };
 
   const activeFiltersConfig = {
     deleteTitle: intl.formatMessage(messages.resetFilters),
     filters: buildFilterChips(),
-    showDeleteButton: tableVars?.ruleName !== '',
-    onDelete: () =>
-      stateSet({ type: 'setTableVars', payload: { ruleName: '', offset: 0 } }),
+    showDeleteButton:
+      tableVars?.ruleName !== '' ||
+      tableVars?.sysMatchStatusFilter !== undefined,
+    onDelete: (event, itemsToRemove, isAll) => {
+      if (isAll) {
+        stateSet({
+          type: 'setTableVars',
+          payload: { ruleName: '', sysMatchStatusFilter: undefined, offset: 0 },
+        });
+      } else {
+        itemsToRemove.map((item) => {
+          if (item.value === 'signature') {
+            stateSet({ type: 'setTableVars', payload: { ruleName: '' } });
+          } else if (item.value === 'status') {
+            const sysMatchStatusChips = tableVars.sysMatchStatusFilter.filter(
+              (status) => status !== item.chips[0].value
+            );
+            const payload = {
+              sysMatchStatusFilter: sysMatchStatusChips.length
+                ? sysMatchStatusChips
+                : undefined,
+              offset: 0,
+            };
+            stateSet({ type: 'setTableVars', payload });
+          }
+        });
+      }
+    },
   };
 
   return (

--- a/src/Components/helpers.js
+++ b/src/Components/helpers.js
@@ -11,15 +11,25 @@ import {
 } from '@patternfly/react-core';
 import { expandMatchMetadata } from './Common';
 
-const filterValues = [
-  { name: 'Not reviewed', value: 'NOT_REVIEWED' },
-  { name: 'In review', value: 'IN_REVIEWED' },
-  { name: 'On-hold', value: 'ON_HOLD' },
-  { name: 'Benign - not malicious malware', value: 'BENIGN' },
-  { name: 'Malware detection test', value: 'TEST' },
-  { name: 'No action - risk accepted', value: 'NO_ACTION' },
-  { name: 'Resolved - malware removed', value: 'RESOLVED' },
+export const filterValues = [
+  { label: 'Not reviewed', value: 'NOT_REVIEWED' },
+  { label: 'In review', value: 'IN_REVIEW' },
+  { label: 'On-hold', value: 'ON_HOLD' },
+  { label: 'Benign - not malicious malware', value: 'BENIGN' },
+  { label: 'Malware detection test', value: 'TEST' },
+  { label: 'No action - risk accepted', value: 'NO_ACTION' },
+  { label: 'Resolved - malware removed', value: 'RESOLVED' },
 ];
+
+export const matchStatusFilterMap = {
+  NOT_REVIEWED: 'Not reviewed',
+  IN_REVIEW: 'In review',
+  ON_HOLD: 'On-hold',
+  BENIGN: 'Benign - not malicious malware',
+  TEST: 'Malware detection test',
+  NO_ACTION: 'No action - risk accepted',
+  RESOLVED: 'Resolved - malware removed',
+};
 
 function formatDate(inputDate) {
   const date = new Date(inputDate);
@@ -67,7 +77,7 @@ export const DropdownBasic = ({ initialValue }) => {
           onClick={onToggleClick}
           isExpanded={isOpen}
         >
-          {filterValues.find((item) => item.value === dropdownValue)?.name}
+          {filterValues.find((item) => item.value === dropdownValue)?.label}
         </MenuToggle>
       )}
       ouiaId="BasicDropdown"
@@ -79,7 +89,7 @@ export const DropdownBasic = ({ initialValue }) => {
             component="button"
             onClick={(event) => onSelect(event, filterValue.value)}
           >
-            {filterValue.name}
+            {filterValue.label}
           </DropdownItem>
         ))}
       </DropdownList>

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -328,6 +328,16 @@ export default defineMessages({
     description: 'Name',
     defaultMessage: 'Name',
   },
+  sigMatchStatus: {
+    id: 'sigMatchStatus',
+    description: 'Match status for signatures',
+    defaultMessage: 'Status',
+  },
+  sysMatchStatus: {
+    id: 'sysMatchStatus',
+    description: 'Match status for systems',
+    defaultMessage: 'Matched status',
+  },
   noMatches: {
     id: 'noMatches',
     description: 'No matches found',

--- a/src/operations/queries.js
+++ b/src/operations/queries.js
@@ -105,6 +105,7 @@ export const GET_SIGNATURE_DETAILS_TABLE = gql`
     $ruleName: String
     $displayName: String
     $hostGroupFilter: [String]
+    $sigMatchStatusFilter: [Acknowledgement!]
   ) {
     rulesList(ruleName: $ruleName) {
       affectedHostsList(
@@ -113,6 +114,7 @@ export const GET_SIGNATURE_DETAILS_TABLE = gql`
         orderBy: $orderBy
         displayName: $displayName
         groupName: $hostGroupFilter
+        status: $sigMatchStatusFilter
       ) {
         id
         displayName
@@ -140,6 +142,7 @@ export const GET_SIGNATURE_DETAILS_TABLE = gql`
         orderBy: $orderBy
         displayName: $displayName
         groupName: $hostGroupFilter
+        status: $sigMatchStatusFilter
       ) {
         totalCount
       }
@@ -228,6 +231,7 @@ export const GET_SYSTEMS_DETAILS_TABLE_PAGE = gql`
     $limit: Int = 10
     $orderBy: [RuleWithMatchesOrderBy!]
     $ruleName: String
+    $sysMatchStatusFilter: [Acknowledgement!]
   ) {
     host(id: $systemId) {
       id
@@ -239,6 +243,7 @@ export const GET_SYSTEMS_DETAILS_TABLE_PAGE = gql`
         offset: $offset
         orderBy: $orderBy
         ruleName: $ruleName
+        status: $sysMatchStatusFilter
       ) {
         totalCount
       }
@@ -247,6 +252,7 @@ export const GET_SYSTEMS_DETAILS_TABLE_PAGE = gql`
         offset: $offset
         orderBy: $orderBy
         ruleName: $ruleName
+        status: $sysMatchStatusFilter
       ) {
         matchCount
         lastMatchDate


### PR DESCRIPTION
This PR adds filtering on "Status" and "Matched status" for the Signature Details and System Details tables, respectively. Both sets of filters apply the same filters to the 2 different tables.

The filters apply both to the systems and signatures that appear in the table, as well as the matches that appear when expanding the system or signature.

To test:
- Go to the Signatures Page
- Click a signature to go to the signature details page Expand a system on the signature details table
- Note the match statuses for the given system
- Apply a status/matched status filter and see updated data Do the same for the Systems Page

Note on how filters should work:

If a signature/system has 1 "Not reviewed" match, 1 "In review" match, and 1 "Resolved" match, then a filter of `IN_REVIEW` would show the said signature/system, but the expanded row would only show the "In review" match. Likewise, a filter of `TEST` would not show the signature/system at all.