### PR TITLE
feat(RHINENG-10989): Add delete match

### DIFF
--- a/src/Components/SigDetailsTable/NewSigDetailsTable.js
+++ b/src/Components/SigDetailsTable/NewSigDetailsTable.js
@@ -1,7 +1,7 @@
-import React, { useEffect, useReducer } from 'react';
+import React, { useEffect, useReducer, useState } from 'react';
 import propTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { useApolloClient, useQuery } from '@apollo/client';
+import { useApolloClient } from '@apollo/client';
 import { isEmpty, uniqWith } from 'lodash';
 import { Icon, Pagination, PaginationVariant } from '@patternfly/react-core';
 import {
@@ -17,7 +17,6 @@ import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/Prima
 import TableToolbar from '@redhat-cloud-services/frontend-components/TableToolbar';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import {
-  GET_HITS_TABLE,
   GET_SIGNATURE_DETAILS_TABLE,
   GET_SIGNATURE_DETAILS_TABLE_GROUPS,
 } from '../../operations/queries';
@@ -27,8 +26,14 @@ import messages from '../../Messages';
 import EmptyAccount from '../SharedComponents/EmptyAccount';
 import './SigDetailsTable.scss';
 import { useWorkspaceFeatureFlag } from '../../Utilities/Hooks';
-import { filterValues, generateCode, matchStatusFilterMap } from '../helpers';
+import {
+  generateCode,
+  matchStatusFilterMap,
+  addRemoveItemInArray,
+} from '../helpers';
 import { sigDetailsTableColumns } from './Columns';
+import { useActionsConfig } from '../../Utilities/Hooks';
+import { filterValues } from '../constants';
 import { NewMatchesTable } from '../TableComponents/NewMatchesTable';
 
 const sortIndices = {
@@ -66,6 +71,14 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
   const intl = useIntl();
   const client = useApolloClient();
   const isWorkspaceEnabled = useWorkspaceFeatureFlag();
+  const [selectedMatches, setSelectedMatches] = useState([]);
+  const [sigDetailsTableLoading, setSigDetailsTableLoading] = useState(false);
+  const [sigDetailsTable, setSigDetailsTable] = useState({});
+  const [sigDetailsTableGroupsLoading, setSigDetailsTableGroupsLoading] =
+    useState(false);
+  const [sigDetailsTableGroups, setSigDetailsTableGroups] = useState({});
+  const [expandedRows, setExpandedRows] = useState([]);
+
   const initialState = {
     tableVars: {
       limit: 10,
@@ -83,19 +96,58 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
     rows: [],
     groups: [],
   };
+
   const [{ tableVars, sortBy, rows, groups }, stateSet] = useReducer(
     tableReducer,
     {
       ...initialState,
     }
   );
-  const { data, loading, error } = useQuery(GET_SIGNATURE_DETAILS_TABLE, {
-    variables: tableVars,
-  });
-  const { data: groupsData, loading: groupsLoading } = useQuery(
-    GET_SIGNATURE_DETAILS_TABLE_GROUPS,
-    { variables: tableVars }
-  );
+
+  const fetchDetailsTable = async (shouldShowLoading) => {
+    if (shouldShowLoading) {
+      setSigDetailsTableLoading(true);
+    }
+
+    let response;
+    try {
+      response = await client.query({
+        query: GET_SIGNATURE_DETAILS_TABLE,
+        fetchPolicy: 'no-cache',
+        variables: tableVars,
+      });
+    } catch (error) {
+      console.error('Error fetching data:', error);
+    }
+
+    setSigDetailsTableLoading(false);
+    setSigDetailsTable(response);
+  };
+
+  const fetchDetailsTableGroups = async (shouldShowLoading) => {
+    if (shouldShowLoading) {
+      setSigDetailsTableGroupsLoading(true);
+    }
+
+    let response;
+    try {
+      response = await client.query({
+        query: GET_SIGNATURE_DETAILS_TABLE_GROUPS,
+        fetchPolicy: 'no-cache',
+        variables: tableVars,
+      });
+    } catch (error) {
+      console.error('Error fetching data:', error);
+    }
+
+    setSigDetailsTableGroupsLoading(false);
+    setSigDetailsTableGroups(response);
+  };
+
+  useEffect(() => {
+    fetchDetailsTable();
+    fetchDetailsTableGroups();
+  }, []);
 
   const page = tableVars.offset / tableVars.limit + 1;
   const columns = sigDetailsTableColumns(isWorkspaceEnabled, intl);
@@ -132,7 +184,7 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
             offset: 0,
           });
         },
-        items: groupsLoading
+        items: sigDetailsTableGroupsLoading
           ? [] // display an empty box whilst the groups are loading
           : isEmpty(groups)
           ? [
@@ -189,33 +241,24 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
       tableVars: { orderBy: orderBy({ index, direction }), offset: 0 },
     });
 
-  const onCollapse = async (e, rowKey, isOpen) => {
-    const collapseRows = [...rows];
-    const host = collapseRows[rowKey + 1].hostData;
-    let hitlistData;
+  const actions = useActionsConfig(
+    selectedMatches,
+    fetchDetailsTable,
+    fetchDetailsTableGroups
+  );
 
-    collapseRows[rowKey] = { ...collapseRows[rowKey], isOpen };
-
-    try {
-      const response = await client.query({
-        query: GET_HITS_TABLE,
-        variables: {
-          ruleName: tableVars.ruleName,
-          hostId: host.id,
-          status: tableVars.sigMatchStatusFilter,
-        },
-      });
-
-      hitlistData = response.data.hitsList;
-    } catch (error) {
-      console.error('Error fetching data:', error);
-    }
-
-    collapseRows[rowKey + 1].cells = [
+  const getExpandedCells = (host) => {
+    return [
       {
         title: (
           <div>
-            <NewMatchesTable hitlistData={hitlistData} />
+            <NewMatchesTable
+              fetchDetailsTable={fetchDetailsTable}
+              hostId={host.id}
+              ruleName={tableVars.ruleName}
+              setSelectedMatches={setSelectedMatches}
+              matchStatusFilter={tableVars.sigMatchStatusFilter}
+            />
             <CodeEditor
               height="250px"
               code={generateCode(host)}
@@ -226,6 +269,20 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
         ),
       },
     ];
+  };
+
+  const onCollapse = async (e, rowKey, isOpen) => {
+    const collapseRows = [...rows];
+    const host = collapseRows[rowKey + 1].hostData;
+
+    collapseRows[rowKey] = { ...collapseRows[rowKey], isOpen };
+
+    setExpandedRows((prev) => {
+      return addRemoveItemInArray(prev, rowKey);
+    });
+
+    collapseRows[rowKey + 1].cells = getExpandedCells(host);
+
     stateSet({ type: 'setRows', payload: collapseRows });
   };
 
@@ -236,7 +293,7 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
         return [
           {
             rowId: key,
-            isOpen: false,
+            isOpen: expandedRows.includes(key * 2) ? true : false,
             cells: [
               {
                 title: (
@@ -291,17 +348,18 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
             parent: key * 2,
             hostData: host,
             fullWidth: true,
-            noPadding: true,
-            cells: [],
+            cells: expandedRows.includes(key * 2) ? getExpandedCells(host) : [],
           },
         ];
       });
 
     stateSet({
       type: 'setRows',
-      payload: rowBuilder(data?.rulesList[0]?.affectedHostsList),
+      payload: rowBuilder(
+        sigDetailsTable?.data?.rulesList[0]?.affectedHostsList
+      ),
     });
-  }, [intl, data]);
+  }, [intl, sigDetailsTable.data]);
 
   useEffect(() => {
     // populates the Group name filter dropdown
@@ -315,13 +373,15 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
     };
 
     let groupsList =
-      getGroupList(groupsData?.rulesList[0]?.affectedHostsList) || [];
+      getGroupList(
+        sigDetailsTableGroups?.data?.rulesList[0]?.affectedHostsList
+      ) || [];
     groupsList = uniqWith(
       groupsList,
       (group1, group2) => group1.label === group2.label
     ); // remove duplicate group names
     stateSet({ type: 'setGroups', payload: groupsList });
-  }, [groupsData]);
+  }, [sigDetailsTableGroups?.data]);
 
   const NoResultsMatch = (
     <MessageState
@@ -442,8 +502,13 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
   return (
     <React.Fragment>
       <PrimaryToolbar
+        actionsConfig={{
+          dropdownProps: { popperProps: { position: 'left' } },
+          actions,
+        }}
         pagination={{
-          itemCount: data?.rulesList[0]?.affectedHosts?.totalCount || 0,
+          itemCount:
+            sigDetailsTable?.data?.rulesList[0]?.affectedHosts?.totalCount || 0,
           page,
           perPage: tableVars.limit,
           onSetPage(e, page) {
@@ -457,7 +522,7 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
         filterConfig={{ items: filterConfigItems(isWorkspaceEnabled) }}
         activeFiltersConfig={activeFiltersConfig}
       />
-      {loading ? (
+      {sigDetailsTableLoading ? (
         <SkeletonTable
           rows={tableVars.limit}
           columns={columns.map((column) => column.title)}
@@ -471,7 +536,7 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
           onCollapse={onCollapse}
           onSort={onSort}
           sortBy={
-            data?.rulesList[0]?.affectedHosts?.totalCount > 0
+            sigDetailsTable?.data?.rulesList[0]?.affectedHosts?.totalCount > 0
               ? sortBy
               : undefined
           }
@@ -482,19 +547,24 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
         </Table>
       )}
 
-      {!error && !loading && affectedCount !== 0 ? (
-        data?.rulesList[0]?.affectedHosts?.totalCount === 0 ? (
+      {!sigDetailsTable?.error &&
+      !sigDetailsTableLoading &&
+      affectedCount !== 0 ? (
+        sigDetailsTable?.data?.rulesList[0]?.affectedHosts?.totalCount === 0 ? (
           NoResultsMatch
         ) : (
           <React.Fragment />
         )
       ) : (
-        !loading && (isEmptyAccount ? EmptyAccountState : NoAffectedHosts)
+        !sigDetailsTableLoading &&
+        (isEmptyAccount ? EmptyAccountState : NoAffectedHosts)
       )}
-      {error && <ErrorState />}
+      {sigDetailsTable?.error && <ErrorState />}
       <TableToolbar isFooter>
         <Pagination
-          itemCount={data?.rulesList[0]?.affectedHosts?.totalCount || 0}
+          itemCount={
+            sigDetailsTable?.data?.rulesList[0]?.affectedHosts?.totalCount || 0
+          }
           widgetId="pagination-options-menu-bottom"
           perPage={tableVars.limit}
           page={page}

--- a/src/Components/SigDetailsTable/NewSigDetailsTable.js
+++ b/src/Components/SigDetailsTable/NewSigDetailsTable.js
@@ -244,7 +244,8 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
   const actions = useActionsConfig(
     selectedMatches,
     fetchDetailsTable,
-    fetchDetailsTableGroups
+    fetchDetailsTableGroups,
+    setSelectedMatches
   );
 
   const getExpandedCells = (host) => {

--- a/src/Components/SigDetailsTable/__tests__/NewSigDetailsTable.tests.js
+++ b/src/Components/SigDetailsTable/__tests__/NewSigDetailsTable.tests.js
@@ -3,7 +3,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';
-import { useQuery, useApolloClient, useMutation } from '@apollo/client';
+import { useApolloClient, useMutation } from '@apollo/client';
 import '@testing-library/jest-dom';
 
 import NewSigDetailsTable from '../NewSigDetailsTable';
@@ -21,13 +21,12 @@ jest.mock('@unleash/proxy-client-react', () => ({
 
 describe('SigDetailsTable', () => {
   beforeEach(() => {
-    useQuery.mockReturnValue(mockSigDetailsTableData);
-
     useApolloClient.mockReturnValue({
       query: async () => {
-        return mockSigHitsList;
+        return mockSigDetailsTableData;
       },
     });
+
     useMutation.mockReturnValue([
       jest.fn(async () => {
         return { data: { acknowledgeHits: { clientMutationId: '123' } } };
@@ -68,8 +67,22 @@ describe('SigDetailsTable', () => {
       </IntlProvider>
     );
 
+    await waitFor(() => {
+      expect(
+        screen.getByRole('row', {
+          name: /details i dont want to set the world on fire n\/a rhel 8\.0 04 jul 2024 1 1/i,
+        })
+      ).toBeVisible();
+    });
+
     const row = screen.getByRole('row', {
       name: /details i dont want to set the world on fire n\/a rhel 8\.0 04 jul 2024 1 1/i,
+    });
+
+    useApolloClient.mockReturnValue({
+      query: async () => {
+        return mockSigHitsList;
+      },
     });
 
     await userEvent.click(

--- a/src/Components/SysDetailsTable/NewSysDetailsTable.js
+++ b/src/Components/SysDetailsTable/NewSysDetailsTable.js
@@ -1,7 +1,7 @@
-import React, { useEffect, useReducer } from 'react';
+import React, { useEffect, useReducer, useState } from 'react';
 import propTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { useApolloClient, useQuery } from '@apollo/client';
+import { useApolloClient } from '@apollo/client';
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
 import {
   Table,
@@ -16,17 +16,20 @@ import TableToolbar from '@redhat-cloud-services/frontend-components/TableToolba
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
 import CodeEditor from '../CodeEditor/CodeEditor';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
-import {
-  GET_HITS_TABLE,
-  GET_SYSTEMS_DETAILS_TABLE_PAGE,
-} from '../../operations/queries';
+import { GET_SYSTEMS_DETAILS_TABLE_PAGE } from '../../operations/queries';
 import MessageState from '../MessageState/MessageState';
 import StatusLabel from '../StatusLabel/StatusLabel';
 import messages from '../../Messages';
 import { Icon } from '@patternfly/react-core';
-import { filterValues, generateCode, matchStatusFilterMap } from '../helpers';
+import {
+  generateCode,
+  matchStatusFilterMap,
+  addRemoveItemInArray,
+} from '../helpers';
 import { sysDetailsTableColumns } from './Columns';
 import { NewMatchesTable } from '../TableComponents/NewMatchesTable';
+import { useActionsConfig } from '../../Utilities/Hooks';
+import { filterValues } from '../constants';
 
 const sortIndices = {
   1: 'NAME',
@@ -59,6 +62,11 @@ const tableReducer = (state, action) => {
 const NewSysDetailsTable = ({ systemId }) => {
   const intl = useIntl();
   const client = useApolloClient();
+  const [selectedMatches, setSelectedMatches] = useState([]);
+  const [sysDetailsTableLoading, setSysDetailsTableLoading] = useState(false);
+  const [sysDetailsTable, setSysDetailsTable] = useState({});
+  const [expandedRows, setExpandedRows] = useState([]);
+
   const initialState = {
     tableVars: {
       limit: 10,
@@ -74,12 +82,34 @@ const NewSysDetailsTable = ({ systemId }) => {
     },
     rows: [],
   };
+
   const [{ tableVars, sortBy, rows }, stateSet] = useReducer(tableReducer, {
     ...initialState,
   });
-  const { data, loading, error } = useQuery(GET_SYSTEMS_DETAILS_TABLE_PAGE, {
-    variables: tableVars,
-  });
+
+  const fetchDetailsTable = async (shouldShowLoading) => {
+    if (shouldShowLoading) {
+      setSysDetailsTableLoading(true);
+    }
+
+    let response;
+    try {
+      response = await client.query({
+        query: GET_SYSTEMS_DETAILS_TABLE_PAGE,
+        fetchPolicy: 'no-cache',
+        variables: tableVars,
+      });
+    } catch (error) {
+      console.error('Error fetching data:', error);
+    }
+
+    setSysDetailsTableLoading(false);
+    setSysDetailsTable(response);
+  };
+
+  useEffect(() => {
+    fetchDetailsTable(true);
+  }, []);
 
   const page = tableVars.offset / tableVars.limit + 1;
   const columns = sysDetailsTableColumns(intl);
@@ -138,33 +168,20 @@ const NewSysDetailsTable = ({ systemId }) => {
       tableVars: { orderBy: orderBy({ index, direction }), offset: 0 },
     });
 
-  const onCollapse = async (e, rowKey, isOpen) => {
-    const collapseRows = [...rows];
-    const host = collapseRows[rowKey + 1].hostData;
-    let hitlistData;
+  const actions = useActionsConfig(selectedMatches, fetchDetailsTable);
 
-    collapseRows[rowKey] = { ...collapseRows[rowKey], isOpen };
-
-    try {
-      const response = await client.query({
-        query: GET_HITS_TABLE,
-        variables: {
-          ruleName: host.name,
-          hostId: systemId,
-          status: tableVars.sysMatchStatusFilter,
-        },
-      });
-
-      hitlistData = response.data.hitsList;
-    } catch (error) {
-      console.error('Error fetching data:', error);
-    }
-
-    collapseRows[rowKey + 1].cells = [
+  const getExpandedCells = (host) => {
+    return [
       {
         title: (
           <div>
-            <NewMatchesTable hitlistData={hitlistData} />
+            <NewMatchesTable
+              fetchDetailsTable={fetchDetailsTable}
+              hostId={systemId}
+              ruleName={host.name}
+              setSelectedMatches={setSelectedMatches}
+              matchStatusFilter={tableVars.sysMatchStatusFilter}
+            />
             <CodeEditor
               height="250px"
               code={generateCode(host)}
@@ -175,6 +192,20 @@ const NewSysDetailsTable = ({ systemId }) => {
         ),
       },
     ];
+  };
+
+  const onCollapse = async (e, rowKey, isOpen) => {
+    const collapseRows = [...rows];
+    const host = collapseRows[rowKey + 1].hostData;
+
+    collapseRows[rowKey] = { ...collapseRows[rowKey], isOpen };
+
+    setExpandedRows((prev) => {
+      return addRemoveItemInArray(prev, rowKey);
+    });
+
+    collapseRows[rowKey + 1].cells = getExpandedCells(host);
+
     stateSet({ type: 'setRows', payload: collapseRows });
   };
 
@@ -183,7 +214,7 @@ const NewSysDetailsTable = ({ systemId }) => {
       data?.host.affectedRulesList.flatMap((data, key) => [
         {
           rowId: key,
-          isOpen: false,
+          isOpen: expandedRows.includes(key * 2) ? true : false,
           cells: [
             {
               title: (
@@ -234,13 +265,13 @@ const NewSysDetailsTable = ({ systemId }) => {
           parent: key * 2,
           hostData: data,
           fullWidth: true,
-          cells: [],
-          noPadding: true,
+          cells: expandedRows.includes(key * 2) ? getExpandedCells(data) : [],
         },
       ]);
 
-    !loading && stateSet({ type: 'setRows', payload: rowBuilder(data) });
-  }, [data, loading]);
+    !sysDetailsTableLoading &&
+      stateSet({ type: 'setRows', payload: rowBuilder(sysDetailsTable.data) });
+  }, [sysDetailsTable.data, sysDetailsTableLoading]);
 
   const buildFilterChips = () => {
     const chips = [];
@@ -299,8 +330,13 @@ const NewSysDetailsTable = ({ systemId }) => {
   return (
     <React.Fragment>
       <PrimaryToolbar
+        actionsConfig={{
+          dropdownProps: { popperProps: { position: 'left' } },
+          actions,
+        }}
         pagination={{
-          itemCount: data?.host?.affectedRules?.totalCount || 0,
+          itemCount:
+            sysDetailsTable?.data?.host?.affectedRules?.totalCount || 0,
           page,
           perPage: tableVars.limit,
           onSetPage(e, page) {
@@ -314,7 +350,7 @@ const NewSysDetailsTable = ({ systemId }) => {
         filterConfig={{ items: filterConfigItems }}
         activeFiltersConfig={activeFiltersConfig}
       />
-      {!loading && (
+      {!sysDetailsTableLoading && (
         <Table
           className="sigTable"
           aria-label="Signature Details table"
@@ -323,7 +359,9 @@ const NewSysDetailsTable = ({ systemId }) => {
           onCollapse={onCollapse}
           onSort={onSort}
           sortBy={
-            data?.host?.affectedRules?.totalCount > 0 ? sortBy : undefined
+            sysDetailsTable?.data?.host?.affectedRules?.totalCount > 0
+              ? sortBy
+              : undefined
           }
           isStickyHeader
         >
@@ -332,14 +370,14 @@ const NewSysDetailsTable = ({ systemId }) => {
         </Table>
       )}
 
-      {loading ? (
+      {sysDetailsTableLoading ? (
         <SkeletonTable
           rows={tableVars.limit}
           columns={columns.map((column) => column.title)}
         />
-      ) : !error ? (
-        data?.host?.lastMatchDate ? (
-          data?.host?.affectedRules?.totalCount === 0 ? (
+      ) : !sysDetailsTable?.error ? (
+        sysDetailsTable?.data?.host?.lastMatchDate ? (
+          sysDetailsTable?.data?.host?.affectedRules?.totalCount === 0 ? (
             <MessageState
               className="pf-c-card"
               icon={SearchIcon}
@@ -370,7 +408,9 @@ const NewSysDetailsTable = ({ systemId }) => {
       )}
       <TableToolbar isFooter>
         <Pagination
-          itemCount={data?.host?.affectedRules?.totalCount || 0}
+          itemCount={
+            sysDetailsTable?.data?.host?.affectedRules?.totalCount || 0
+          }
           widgetId="pagination-options-menu-bottom"
           perPage={tableVars.limit}
           page={page}

--- a/src/Components/SysDetailsTable/__tests__/NewSysDetailsTable.tests.js
+++ b/src/Components/SysDetailsTable/__tests__/NewSysDetailsTable.tests.js
@@ -3,7 +3,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';
-import { useQuery, useApolloClient, useMutation } from '@apollo/client';
+import { useApolloClient, useMutation } from '@apollo/client';
 import '@testing-library/jest-dom';
 
 import NewSysDetailsTable from '../NewSysDetailsTable';
@@ -16,11 +16,9 @@ jest.mock('@apollo/client');
 
 describe('SysDetailsTable', () => {
   beforeEach(() => {
-    useQuery.mockReturnValue(mockSysDetailsTableData);
-
     useApolloClient.mockReturnValue({
       query: async () => {
-        return mockSysHitsList;
+        return mockSysDetailsTableData;
       },
     });
 
@@ -41,7 +39,7 @@ describe('SysDetailsTable', () => {
     );
 
     expect(
-      screen.getByRole('button', {
+      screen.getByRole('columnheader', {
         name: /new matches/i,
       })
     ).toBeVisible();
@@ -114,8 +112,22 @@ describe('SysDetailsTable', () => {
       </IntlProvider>
     );
 
+    await waitFor(() => {
+      expect(
+        screen.getByRole('row', {
+          name: /details dalinar matched 27 jun 2024 1 1/i,
+        })
+      ).toBeVisible();
+    });
+
     const row = screen.getByRole('row', {
       name: /details dalinar matched 27 jun 2024 1 1/i,
+    });
+
+    useApolloClient.mockReturnValue({
+      query: async () => {
+        return mockSysHitsList;
+      },
     });
 
     await userEvent.click(

--- a/src/Components/TableComponents/DropdownBasic.js
+++ b/src/Components/TableComponents/DropdownBasic.js
@@ -1,17 +1,15 @@
-import React from 'react';
-
+import React, { useState } from 'react';
 import {
   Dropdown,
   DropdownItem,
   DropdownList,
   MenuToggle,
 } from '@patternfly/react-core';
-import { useState } from 'react';
 import PropTypes from 'prop-types';
-import { filterValues } from '../helpers';
 
 export const DropdownBasic = ({
   dropdownValue,
+  dropdownValues,
   onChange,
   setDropdownValue,
 }) => {
@@ -39,13 +37,13 @@ export const DropdownBasic = ({
           onClick={onToggleClick}
           isExpanded={isOpen}
         >
-          {filterValues.find((item) => item.value === dropdownValue)?.label}
+          {dropdownValues.find((item) => item.value === dropdownValue)?.label}
         </MenuToggle>
       )}
       ouiaId="BasicDropdown"
     >
       <DropdownList>
-        {filterValues.map((filterValue) => (
+        {dropdownValues.map((filterValue) => (
           <DropdownItem
             aria-label={`${filterValue.label}`}
             key={filterValue.value}
@@ -62,6 +60,7 @@ export const DropdownBasic = ({
 
 DropdownBasic.propTypes = {
   dropdownValue: PropTypes.string,
+  dropdownValues: PropTypes.array,
   onChange: PropTypes.func,
   setDropdownValue: PropTypes.func,
 };

--- a/src/Components/TableComponents/NewMatchesTable.js
+++ b/src/Components/TableComponents/NewMatchesTable.js
@@ -1,33 +1,80 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useApolloClient } from '@apollo/client';
 import PropTypes from 'prop-types';
-import { Table, Thead, Tr, Th, Tbody } from '@patternfly/react-table';
+import { Table, Thead, Th, Tbody, Tr } from '@patternfly/react-table';
+import { GET_HITS_TABLE } from '../../operations/queries';
+import { SkeletonTable } from '@patternfly/react-component-groups';
 import { NewMatchesTableRow } from './NewMatchesTableRow';
 
-export const NewMatchesTable = ({ hitlistData }) => {
+export const NewMatchesTable = ({
+  fetchDetailsTable,
+  hostId,
+  ruleName,
+  setSelectedMatches,
+  matchStatusFilter,
+}) => {
+  const client = useApolloClient();
+  const [areMatchesLoading, setAreMatchesLoading] = useState(false);
+  const [hitlistData, setHitlistData] = useState([]);
   const columnNames = {
-    scanDate: 'Dates matched',
-    matchedStatus: 'Match status',
-    note: 'Note',
+    blank: { name: '', width: 5 },
+    scanDate: { name: 'Dates matched', width: 20 },
+    matchedStatus: { name: 'Match status', width: 20 },
+    note: { name: 'Note', width: 50 },
+    actions: { name: '', width: 5 },
   };
 
-  return (
-    <Table
-      aria-label="Simple table"
-      variant="compact"
-      style={{ width: '100%', borderTop: '1px solid #d2d2d2' }}
-    >
+  const fetchMatches = async () => {
+    setAreMatchesLoading(true);
+    try {
+      const response = await client.query({
+        query: GET_HITS_TABLE,
+        fetchPolicy: 'no-cache',
+        variables: {
+          ruleName: ruleName,
+          hostId: hostId,
+          status: matchStatusFilter,
+        },
+      });
+
+      console.log(response, 'response');
+
+      setAreMatchesLoading(false);
+      setHitlistData(response.data.hitsList);
+    } catch (error) {
+      console.error('Error fetching data:', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchMatches();
+  }, []);
+
+  return areMatchesLoading || !hitlistData?.length ? (
+    <SkeletonTable rows={5} columns={Object.values(columnNames).length} />
+  ) : (
+    <Table aria-label="Simple table" variant="compact">
       <Thead style={{ borderBottom: '1px solid #d2d2d2' }}>
         <Tr>
-          {Object.values(columnNames).map((column) => (
-            <Th key={column}>{column}</Th>
+          {Object.values(columnNames).map((column, idx) => (
+            <Th key={`column-title-${column.name}-${idx}`} width={column.width}>
+              {column.name}
+            </Th>
           ))}
         </Tr>
       </Thead>
       <Tbody>
-        {hitlistData?.map((data) => (
-          <Tr key={data.id}>
-            <NewMatchesTableRow data={data} columnNames={columnNames} />
-          </Tr>
+        {hitlistData?.map((data, idx) => (
+          <NewMatchesTableRow
+            key={`${data.id}-row`}
+            columnNames={columnNames}
+            data={data}
+            fetchDetailsTable={fetchDetailsTable}
+            fetchMatches={fetchMatches}
+            hostId={hostId}
+            rowIndex={idx}
+            setSelectedMatches={setSelectedMatches}
+          />
         ))}
       </Tbody>
     </Table>
@@ -35,5 +82,9 @@ export const NewMatchesTable = ({ hitlistData }) => {
 };
 
 NewMatchesTable.propTypes = {
-  hitlistData: PropTypes.any,
+  fetchDetailsTable: PropTypes.func,
+  hostId: PropTypes.string,
+  ruleName: PropTypes.string,
+  setSelectedMatches: PropTypes.func,
+  matchStatusFilter: PropTypes.object,
 };

--- a/src/Components/TableComponents/NewMatchesTableRow.js
+++ b/src/Components/TableComponents/NewMatchesTableRow.js
@@ -1,27 +1,45 @@
-import React from 'react';
-import { Td } from '@patternfly/react-table';
-import PropTypes from 'prop-types';
-import { useCallback, useState } from 'react';
-import { useVerifyInput } from '../useVerifyInput';
+import React, { useCallback, useState } from 'react';
 import { useMutation } from '@apollo/client';
-import { EDIT_MATCH } from '../../operations/mutations';
-import { TextInputGroupBasic } from './TextInputBasic';
+import PropTypes from 'prop-types';
+import { ActionsColumn, Tr, Td } from '@patternfly/react-table';
+import { DELETE_MATCH, EDIT_MATCH } from '../../operations/mutations';
+import { formatDate, addRemoveItemInArray } from '../helpers';
 import { DropdownBasic } from './DropdownBasic';
+import { TextInputBasic } from './TextInputBasic';
+import { filterValues } from '../constants';
+import { useVerifyInput } from '../useVerifyInput';
 
-function formatDate(inputDate) {
-  const date = new Date(inputDate);
-
-  const day = date.getUTCDate().toString().padStart(2, '0');
-  const month = date.toLocaleString('default', { month: 'long' });
-  const year = date.getUTCFullYear();
-
-  return `${day}-${month}-${year}`;
-}
-
-export const NewMatchesTableRow = ({ data, columnNames }) => {
-  const [executeMutation] = useMutation(EDIT_MATCH);
+export const NewMatchesTableRow = ({
+  columnNames,
+  data,
+  fetchDetailsTable,
+  fetchMatches,
+  hostId,
+  rowIndex,
+  setSelectedMatches,
+}) => {
+  const [isSelected, setIsSelected] = useState(false);
   const [textValue, setTextValue] = useState(data.justification);
   const [dropdownValue, setDropdownValue] = useState(data.status);
+  const [deleteMatch] = useMutation(DELETE_MATCH, {
+    variables: { input: [data.id] },
+  });
+  const [executeMutation] = useMutation(EDIT_MATCH);
+
+  const onSelectMatch = (data) => {
+    setIsSelected(!isSelected);
+    setSelectedMatches((prev) => {
+      return addRemoveItemInArray(prev, data.id);
+    });
+  };
+
+  const onDeleteMatch = async () => {
+    await deleteMatch();
+    await fetchDetailsTable(false);
+    await fetchMatches(hostId);
+    setSelectedMatches([]);
+  };
+
   //when i type fresh, and then do dropdown, textValue is null
   const handleDropdownChange = useCallback(
     (newDropdownValue) => {
@@ -41,6 +59,7 @@ export const NewMatchesTableRow = ({ data, columnNames }) => {
     },
     [executeMutation, data.id, dropdownValue, textValue]
   );
+
   // Debounced execute mutation for text input changes
   const memoizedExecuteMutation = useCallback(() => {
     executeMutation({
@@ -59,28 +78,46 @@ export const NewMatchesTableRow = ({ data, columnNames }) => {
   const isLoading = verifiedStatus === 'loading';
 
   return (
-    <>
-      <Td dataLabel={columnNames.scanDate}>{formatDate(data.scanDate)}</Td>
+    <Tr>
+      <Td
+        select={{
+          rowIndex,
+          onSelect: () => onSelectMatch(data),
+          isSelected: isSelected,
+        }}
+      />
+      <Td dataLabel={columnNames.scanDate.name}>{formatDate(data.scanDate)}</Td>
       <Td style={{ maxWidth: '100px' }}>
         <DropdownBasic
           dropdownValue={dropdownValue}
+          dropdownValues={filterValues}
           onChange={handleDropdownChange}
           setDropdownValue={setDropdownValue}
         />
       </Td>
       <Td>
-        <TextInputGroupBasic
+        <TextInputBasic
           textValue={textValue}
           setTextValue={setTextValue}
           verifiedStatus={verifiedStatus}
           isLoading={isLoading}
         />
       </Td>
-    </>
+      <Td style={{ textAlign: 'right' }}>
+        <ActionsColumn
+          items={[{ title: 'Delete match', onClick: () => onDeleteMatch() }]}
+        />
+      </Td>
+    </Tr>
   );
 };
 
 NewMatchesTableRow.propTypes = {
-  data: PropTypes.object,
   columnNames: PropTypes.object,
+  data: PropTypes.object,
+  fetchDetailsTable: PropTypes.func,
+  fetchMatches: PropTypes.func,
+  hostId: PropTypes.string,
+  rowIndex: PropTypes.number,
+  setSelectedMatches: PropTypes.func,
 };

--- a/src/Components/TableComponents/NewMatchesTableRow.js
+++ b/src/Components/TableComponents/NewMatchesTableRow.js
@@ -37,7 +37,6 @@ export const NewMatchesTableRow = ({
     await deleteMatch();
     await fetchDetailsTable(false);
     await fetchMatches(hostId);
-    setSelectedMatches([]);
   };
 
   //when i type fresh, and then do dropdown, textValue is null

--- a/src/Components/TableComponents/TextInputBasic.js
+++ b/src/Components/TableComponents/TextInputBasic.js
@@ -1,7 +1,5 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
-
 import {
   Flex,
   HelperText,
@@ -11,10 +9,9 @@ import {
   TextInputGroup,
   TextInputGroupMain,
 } from '@patternfly/react-core';
-
 import { CheckCircleIcon, InProgressIcon } from '@patternfly/react-icons';
 
-export const TextInputGroupBasic = ({
+export const TextInputBasic = ({
   textValue,
   setTextValue,
   verifiedStatus,
@@ -53,7 +50,7 @@ export const TextInputGroupBasic = ({
   );
 };
 
-TextInputGroupBasic.propTypes = {
+TextInputBasic.propTypes = {
   textValue: PropTypes.string,
   setTextValue: PropTypes.func,
   verifiedStatus: PropTypes.string,

--- a/src/Components/constants.js
+++ b/src/Components/constants.js
@@ -1,0 +1,9 @@
+export const filterValues = [
+  { label: 'Not reviewed', value: 'NOT_REVIEWED' },
+  { label: 'In review', value: 'IN_REVIEW' },
+  { label: 'On-hold', value: 'ON_HOLD' },
+  { label: 'Benign - not malicious malware', value: 'BENIGN' },
+  { label: 'Malware detection test', value: 'TEST' },
+  { label: 'No action - risk accepted', value: 'NO_ACTION' },
+  { label: 'Resolved - malware removed', value: 'RESOLVED' },
+];

--- a/src/Components/helpers.js
+++ b/src/Components/helpers.js
@@ -1,15 +1,5 @@
 import { expandMatchMetadata } from './Common';
 
-export const filterValues = [
-  { label: 'Not reviewed', value: 'NOT_REVIEWED' },
-  { label: 'In review', value: 'IN_REVIEW' },
-  { label: 'On-hold', value: 'ON_HOLD' },
-  { label: 'Benign - not malicious malware', value: 'BENIGN' },
-  { label: 'Malware detection test', value: 'TEST' },
-  { label: 'No action - risk accepted', value: 'NO_ACTION' },
-  { label: 'Resolved - malware removed', value: 'RESOLVED' },
-];
-
 export const matchStatusFilterMap = {
   NOT_REVIEWED: 'Not reviewed',
   IN_REVIEW: 'In review',
@@ -18,6 +8,24 @@ export const matchStatusFilterMap = {
   TEST: 'Malware detection test',
   NO_ACTION: 'No action - risk accepted',
   RESOLVED: 'Resolved - malware removed',
+};
+
+export function formatDate(inputDate) {
+  const date = new Date(inputDate);
+
+  const day = date.getUTCDate().toString().padStart(2, '0');
+  const month = date.toLocaleString('default', { month: 'long' });
+  const year = date.getUTCFullYear();
+
+  return `${day}-${month}-${year}`;
+}
+
+export const addRemoveItemInArray = (data, item) => {
+  if (data.includes(item)) {
+    return data.filter((x) => x != item);
+  } else {
+    return [...data, item];
+  }
 };
 
 export const generateCode = (host) => {

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -1,4 +1,8 @@
 import { useFlag, useFlagsStatus } from '@unleash/proxy-client-react';
+import { useMutation } from '@apollo/client';
+import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { RBACPermissions } from '../Components/Common';
+import { DELETE_MATCH } from '../operations/mutations';
 
 export const useFeatureFlag = (flag) => {
   const { flagsReady } = useFlagsStatus();
@@ -11,3 +15,34 @@ export const useWorkspaceFeatureFlag = () =>
 
 export const useNewMatchesFeatureFlag = () =>
   useFeatureFlag('insights.malware.matches');
+
+export const useActionsConfig = (
+  selectedMatches,
+  fetchDetailsTable,
+  fetchDetailsTableGroups
+) => {
+  const [deleteMatch] = useMutation(DELETE_MATCH);
+  const { hasAccess: hasDeleteAccess, isLoading: isDeleteAccessLoading } =
+    usePermissions('malware-detection', RBACPermissions.write);
+
+  return [
+    '',
+    {
+      label: 'Delete matches',
+      props: !isDeleteAccessLoading && !hasDeleteAccess,
+      onClick: () => {
+        try {
+          deleteMatch({
+            variables: {
+              input: selectedMatches,
+            },
+          });
+          fetchDetailsTable && fetchDetailsTable(true);
+          fetchDetailsTableGroups && fetchDetailsTableGroups(true);
+        } catch (error) {
+          console.error('Error fetching data:', error);
+        }
+      },
+    },
+  ];
+};

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -19,7 +19,8 @@ export const useNewMatchesFeatureFlag = () =>
 export const useActionsConfig = (
   selectedMatches,
   fetchDetailsTable,
-  fetchDetailsTableGroups
+  fetchDetailsTableGroups,
+  setSelectedMatches
 ) => {
   const [deleteMatch] = useMutation(DELETE_MATCH);
   const { hasAccess: hasDeleteAccess, isLoading: isDeleteAccessLoading } =
@@ -39,6 +40,7 @@ export const useActionsConfig = (
           });
           fetchDetailsTable && fetchDetailsTable(true);
           fetchDetailsTableGroups && fetchDetailsTableGroups(true);
+          setSelectedMatches([]);
         } catch (error) {
           console.error('Error fetching data:', error);
         }


### PR DESCRIPTION
This PR adds functionality to delete a single match detail line as well as multiple match details across multiple systems/signatures.

To test:
- Navigate to Malware
- Navigate to Signatures/Systems
- Click on a Signature/System
- Expand any number of rows with Matches
- Use delete functionality

To test single delete:
- Find a match in the table nested inside of the expanded row
- Click the kebab on the far right of the row
- Click "Delete match"

The table should show loading rows and then refresh with the match removed and all previously expanded rows still expanded. The parent table will also refresh in the background without loading rows and you should see the "New matches" and "Total matches" values update to reflect the deletion you just made.

To test bulk delete:
- Select any number of matches from multiple signatures/systems using
  the checkboxes
- Click the kebab in the toolbar of the parent table
- Click "Delete matches"

The entire parent table should show loading rows and then refresh with previously expanded rows still expanded and all deleted rows removed and values updated.