### PR TITLE
feat(RHINENG-11758): disable delete and edit without perms

### DIFF
--- a/src/Components/SigDetailsTable/NewSigDetailsTable.js
+++ b/src/Components/SigDetailsTable/NewSigDetailsTable.js
@@ -35,6 +35,8 @@ import { sigDetailsTableColumns } from './Columns';
 import { useActionsConfig } from '../../Utilities/Hooks';
 import { filterValues } from '../constants';
 import { NewMatchesTable } from '../TableComponents/NewMatchesTable';
+import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { RBACPermissions } from '../Common';
 
 const sortIndices = {
   1: 'DISPLAY_NAME',
@@ -71,6 +73,8 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
   const intl = useIntl();
   const client = useApolloClient();
   const isWorkspaceEnabled = useWorkspaceFeatureFlag();
+  const { hasAccess: hasWriteAccess, isLoading: isWriteAccessLoading } =
+    usePermissions('malware-detection', RBACPermissions.write);
   const [selectedMatches, setSelectedMatches] = useState([]);
   const [sigDetailsTableLoading, setSigDetailsTableLoading] = useState(false);
   const [sigDetailsTable, setSigDetailsTable] = useState({});
@@ -242,6 +246,8 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
     });
 
   const actions = useActionsConfig(
+    isWriteAccessLoading,
+    hasWriteAccess,
     selectedMatches,
     fetchDetailsTable,
     fetchDetailsTableGroups,
@@ -255,10 +261,12 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
           <div>
             <NewMatchesTable
               fetchDetailsTable={fetchDetailsTable}
+              hasWriteAccess={hasWriteAccess}
               hostId={host.id}
+              isWriteAccessLoading={isWriteAccessLoading}
+              matchStatusFilter={tableVars.sigMatchStatusFilter}
               ruleName={tableVars.ruleName}
               setSelectedMatches={setSelectedMatches}
-              matchStatusFilter={tableVars.sigMatchStatusFilter}
             />
             <CodeEditor
               height="250px"

--- a/src/Components/SigDetailsTable/__tests__/NewSigDetailsTable.tests.js
+++ b/src/Components/SigDetailsTable/__tests__/NewSigDetailsTable.tests.js
@@ -32,6 +32,14 @@ describe('SigDetailsTable', () => {
         return { data: { acknowledgeHits: { clientMutationId: '123' } } };
       }),
     ]);
+
+    jest.mock(
+      '@redhat-cloud-services/frontend-components-utilities/RBACHook',
+      () => ({
+        esModule: true,
+        usePermissions: () => ({ hasAccess: true, isLoading: false }),
+      })
+    );
   });
 
   it('should render New matches column', async () => {
@@ -156,5 +164,47 @@ describe('SigDetailsTable', () => {
         name: /close not reviewed/i,
       })
     ).toHaveLength(0);
+  });
+
+  it('should render disabled actions column', async () => {
+    jest.mock(
+      '@redhat-cloud-services/frontend-components-utilities/RBACHook',
+      () => ({
+        esModule: true,
+        usePermissions: () => ({ hasAccess: true, isLoading: false }),
+      })
+    );
+
+    render(
+      <IntlProvider locale="en">
+        <Router>
+          <NewSigDetailsTable
+            ruleName="bingo bango bongo"
+            affectedCount={1}
+            isEmptyAccount={false}
+          />
+        </Router>
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('row', {
+          name: /details i dont want to set the world on fire n\/a rhel 8\.0 04 jul 2024 1 1/i,
+        })
+      ).toBeVisible();
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /kebab dropdown toggle/i,
+      })
+    );
+
+    expect(
+      screen.getByRole('menuitem', {
+        name: /delete matches/i,
+      })
+    ).toBeDisabled();
   });
 });

--- a/src/Components/SysDetailsTable/NewSysDetailsTable.js
+++ b/src/Components/SysDetailsTable/NewSysDetailsTable.js
@@ -30,6 +30,8 @@ import { sysDetailsTableColumns } from './Columns';
 import { NewMatchesTable } from '../TableComponents/NewMatchesTable';
 import { useActionsConfig } from '../../Utilities/Hooks';
 import { filterValues } from '../constants';
+import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { RBACPermissions } from '../Common';
 
 const sortIndices = {
   1: 'NAME',
@@ -62,6 +64,8 @@ const tableReducer = (state, action) => {
 const NewSysDetailsTable = ({ systemId }) => {
   const intl = useIntl();
   const client = useApolloClient();
+  const { hasAccess: hasWriteAccess, isLoading: isWriteAccessLoading } =
+    usePermissions('malware-detection', RBACPermissions.write);
   const [selectedMatches, setSelectedMatches] = useState([]);
   const [sysDetailsTableLoading, setSysDetailsTableLoading] = useState(false);
   const [sysDetailsTable, setSysDetailsTable] = useState({});
@@ -168,7 +172,13 @@ const NewSysDetailsTable = ({ systemId }) => {
       tableVars: { orderBy: orderBy({ index, direction }), offset: 0 },
     });
 
-  const actions = useActionsConfig(selectedMatches, fetchDetailsTable);
+  const actions = useActionsConfig(
+    isWriteAccessLoading,
+    hasWriteAccess,
+    selectedMatches,
+    fetchDetailsTable,
+    setSelectedMatches
+  );
 
   const getExpandedCells = (host) => {
     return [
@@ -177,10 +187,12 @@ const NewSysDetailsTable = ({ systemId }) => {
           <div>
             <NewMatchesTable
               fetchDetailsTable={fetchDetailsTable}
+              hasWriteAccess={hasWriteAccess}
               hostId={systemId}
+              isWriteAccessLoading={isWriteAccessLoading}
+              matchStatusFilter={tableVars.sysMatchStatusFilter}
               ruleName={host.name}
               setSelectedMatches={setSelectedMatches}
-              matchStatusFilter={tableVars.sysMatchStatusFilter}
             />
             <CodeEditor
               height="250px"

--- a/src/Components/SysDetailsTable/__tests__/NewSysDetailsTable.tests.js
+++ b/src/Components/SysDetailsTable/__tests__/NewSysDetailsTable.tests.js
@@ -27,6 +27,14 @@ describe('SysDetailsTable', () => {
         return { data: { acknowledgeHits: { clientMutationId: '123' } } };
       }),
     ]);
+
+    jest.mock(
+      '@redhat-cloud-services/frontend-components-utilities/RBACHook',
+      () => ({
+        esModule: true,
+        usePermissions: () => ({ hasAccess: true, isLoading: false }),
+      })
+    );
   });
 
   it('should render SysDetailsTable', async () => {
@@ -139,5 +147,47 @@ describe('SysDetailsTable', () => {
     await waitFor(() => {
       expect(screen.getByText('27 June 2024')).toBeVisible();
     });
+  });
+
+  it('should render disabled actions column', async () => {
+    jest.mock(
+      '@redhat-cloud-services/frontend-components-utilities/RBACHook',
+      () => ({
+        esModule: true,
+        usePermissions: () => ({ hasAccess: true, isLoading: false }),
+      })
+    );
+
+    render(
+      <IntlProvider locale="en">
+        <Router>
+          <NewSysDetailsTable
+            ruleName="bingo bango bongo"
+            affectedCount={1}
+            isEmptyAccount={false}
+          />
+        </Router>
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('row', {
+          name: /details dalinar matched 27 jun 2024 1 1/i,
+        })
+      ).toBeVisible();
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /kebab dropdown toggle/i,
+      })
+    );
+
+    expect(
+      screen.getByRole('menuitem', {
+        name: /delete matches/i,
+      })
+    ).toBeDisabled();
   });
 });

--- a/src/Components/TableComponents/DropdownBasic.js
+++ b/src/Components/TableComponents/DropdownBasic.js
@@ -10,6 +10,8 @@ import PropTypes from 'prop-types';
 export const DropdownBasic = ({
   dropdownValue,
   dropdownValues,
+  hasWriteAccess,
+  isWriteAccessLoading,
   onChange,
   setDropdownValue,
 }) => {
@@ -35,6 +37,7 @@ export const DropdownBasic = ({
           style={{ maxWidth: '75%' }}
           ref={toggleRef}
           onClick={onToggleClick}
+          isDisabled={!isWriteAccessLoading && !hasWriteAccess}
           isExpanded={isOpen}
         >
           {dropdownValues.find((item) => item.value === dropdownValue)?.label}
@@ -61,6 +64,8 @@ export const DropdownBasic = ({
 DropdownBasic.propTypes = {
   dropdownValue: PropTypes.string,
   dropdownValues: PropTypes.array,
+  hasWriteAccess: PropTypes.bool,
+  isWriteAccessLoading: PropTypes.bool,
   onChange: PropTypes.func,
   setDropdownValue: PropTypes.func,
 };

--- a/src/Components/TableComponents/NewMatchesTable.js
+++ b/src/Components/TableComponents/NewMatchesTable.js
@@ -8,10 +8,12 @@ import { NewMatchesTableRow } from './NewMatchesTableRow';
 
 export const NewMatchesTable = ({
   fetchDetailsTable,
+  hasWriteAccess,
   hostId,
+  isWriteAccessLoading,
+  matchStatusFilter,
   ruleName,
   setSelectedMatches,
-  matchStatusFilter,
 }) => {
   const client = useApolloClient();
   const [areMatchesLoading, setAreMatchesLoading] = useState(false);
@@ -37,8 +39,6 @@ export const NewMatchesTable = ({
         },
       });
 
-      console.log(response, 'response');
-
       setAreMatchesLoading(false);
       setHitlistData(response.data.hitsList);
     } catch (error) {
@@ -56,11 +56,19 @@ export const NewMatchesTable = ({
     <Table aria-label="Simple table" variant="compact">
       <Thead style={{ borderBottom: '1px solid #d2d2d2' }}>
         <Tr>
-          {Object.values(columnNames).map((column, idx) => (
-            <Th key={`column-title-${column.name}-${idx}`} width={column.width}>
-              {column.name}
-            </Th>
-          ))}
+          {Object.values(columnNames).map(
+            (column, idx) =>
+              !isWriteAccessLoading &&
+              hasWriteAccess &&
+              column === 'actions' && (
+                <Th
+                  key={`column-title-${column.name}-${idx}`}
+                  width={column.width}
+                >
+                  {column.name}
+                </Th>
+              )
+          )}
         </Tr>
       </Thead>
       <Tbody>
@@ -71,7 +79,9 @@ export const NewMatchesTable = ({
             data={data}
             fetchDetailsTable={fetchDetailsTable}
             fetchMatches={fetchMatches}
+            hasWriteAccess={hasWriteAccess}
             hostId={hostId}
+            isWriteAccessLoading={isWriteAccessLoading}
             rowIndex={idx}
             setSelectedMatches={setSelectedMatches}
           />
@@ -83,8 +93,10 @@ export const NewMatchesTable = ({
 
 NewMatchesTable.propTypes = {
   fetchDetailsTable: PropTypes.func,
+  hasWriteAccess: PropTypes.bool,
   hostId: PropTypes.string,
+  isWriteAccessLoading: PropTypes.bool,
+  matchStatusFilter: PropTypes.object,
   ruleName: PropTypes.string,
   setSelectedMatches: PropTypes.func,
-  matchStatusFilter: PropTypes.object,
 };

--- a/src/Components/TableComponents/NewMatchesTableRow.js
+++ b/src/Components/TableComponents/NewMatchesTableRow.js
@@ -15,7 +15,9 @@ export const NewMatchesTableRow = ({
   data,
   fetchDetailsTable,
   fetchMatches,
+  hasWriteAccess,
   hostId,
+  isWriteAccessLoading,
   rowIndex,
   setSelectedMatches,
 }) => {
@@ -84,6 +86,7 @@ export const NewMatchesTableRow = ({
           rowIndex,
           onSelect: () => onSelectMatch(data),
           isSelected: isSelected,
+          isDisabled: !isWriteAccessLoading && !hasWriteAccess,
         }}
       />
       <Td dataLabel={columnNames.scanDate.name}>
@@ -93,23 +96,29 @@ export const NewMatchesTableRow = ({
         <DropdownBasic
           dropdownValue={dropdownValue}
           dropdownValues={filterValues}
+          hasWriteAccess={hasWriteAccess}
+          isWriteAccessLoading={isWriteAccessLoading}
           onChange={handleDropdownChange}
           setDropdownValue={setDropdownValue}
         />
       </Td>
       <Td>
         <TextInputBasic
-          textValue={textValue}
-          setTextValue={setTextValue}
-          verifiedStatus={verifiedStatus}
+          hasWriteAccess={hasWriteAccess}
           isLoading={isLoading}
+          isWriteAccessLoading={isWriteAccessLoading}
+          setTextValue={setTextValue}
+          textValue={textValue}
+          verifiedStatus={verifiedStatus}
         />
       </Td>
-      <Td style={{ textAlign: 'right' }}>
-        <ActionsColumn
-          items={[{ title: 'Delete match', onClick: () => onDeleteMatch() }]}
-        />
-      </Td>
+      {!isWriteAccessLoading && hasWriteAccess && (
+        <Td style={{ textAlign: 'right' }}>
+          <ActionsColumn
+            items={[{ title: 'Delete match', onClick: () => onDeleteMatch() }]}
+          />
+        </Td>
+      )}
     </Tr>
   );
 };
@@ -119,7 +128,9 @@ NewMatchesTableRow.propTypes = {
   data: PropTypes.object,
   fetchDetailsTable: PropTypes.func,
   fetchMatches: PropTypes.func,
+  hasWriteAccess: PropTypes.bool,
   hostId: PropTypes.string,
+  isWriteAccessLoading: PropTypes.bool,
   rowIndex: PropTypes.number,
   setSelectedMatches: PropTypes.func,
 };

--- a/src/Components/TableComponents/NewMatchesTableRow.test.js
+++ b/src/Components/TableComponents/NewMatchesTableRow.test.js
@@ -145,7 +145,7 @@ describe('NewMatchesTableRow Tests', () => {
 
     expect(
       screen.getByRole('textbox', {
-        name: /type to filter/i,
+        name: '',
       })
     ).toBeDisabled();
 

--- a/src/Components/TableComponents/NewMatchesTableRow.test.js
+++ b/src/Components/TableComponents/NewMatchesTableRow.test.js
@@ -42,7 +42,12 @@ describe('NewMatchesTableRow Tests', () => {
         <table>
           <tbody>
             <tr>
-              <NewMatchesTableRow data={mockData} columnNames={columnNames} />
+              <NewMatchesTableRow
+                data={mockData}
+                columnNames={columnNames}
+                hasWriteAccess={true}
+                isWriteAccessLoading={false}
+              />
             </tr>
           </tbody>
         </table>
@@ -52,6 +57,30 @@ describe('NewMatchesTableRow Tests', () => {
     const inputs = await screen.findAllByDisplayValue(/initial justification/i);
     expect(inputs.length).toBe(2);
     expect(inputs[0]).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {
+        name: /kebab toggle/i,
+      })
+    ).toBeVisible();
+
+    expect(
+      screen.getByRole('button', {
+        name: /menutoggle/i,
+      })
+    ).toBeEnabled();
+
+    expect(
+      screen.getByRole('textbox', {
+        name: /type to filter/i,
+      })
+    ).toBeEnabled();
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: /select all rows/i,
+      })
+    ).toBeEnabled();
   });
 
   it('handles dropdown change correctly', async () => {
@@ -60,7 +89,12 @@ describe('NewMatchesTableRow Tests', () => {
         <table>
           <tbody>
             <tr>
-              <NewMatchesTableRow data={mockData} columnNames={columnNames} />
+              <NewMatchesTableRow
+                data={mockData}
+                columnNames={columnNames}
+                hasWriteAccess={true}
+                isWriteAccessLoading={false}
+              />
             </tr>
           </tbody>
         </table>
@@ -69,6 +103,7 @@ describe('NewMatchesTableRow Tests', () => {
 
     const dropdownTrigger = screen.getByLabelText('MenuToggle');
     fireEvent.click(dropdownTrigger);
+
     const menuItem = screen.getByLabelText('In review');
     fireEvent.click(menuItem);
 
@@ -76,5 +111,48 @@ describe('NewMatchesTableRow Tests', () => {
     await waitFor(() => {
       expect(screen.getByText(/In review/i)).toBeInTheDocument();
     });
+  });
+
+  it('renders disabled correctly', async () => {
+    render(
+      <MockedProvider>
+        <table>
+          <tbody>
+            <tr>
+              <NewMatchesTableRow
+                data={mockData}
+                columnNames={columnNames}
+                hasWriteAccess={false}
+                isWriteAccessLoading={false}
+              />
+            </tr>
+          </tbody>
+        </table>
+      </MockedProvider>
+    );
+
+    expect(
+      screen.queryAllByRole('button', {
+        name: /kebab toggle/i,
+      })
+    ).toHaveLength(0);
+
+    expect(
+      screen.getByRole('button', {
+        name: /menutoggle/i,
+      })
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole('textbox', {
+        name: /type to filter/i,
+      })
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: /select all rows/i,
+      })
+    ).toBeDisabled();
   });
 });

--- a/src/Components/TableComponents/TextInputBasic.js
+++ b/src/Components/TableComponents/TextInputBasic.js
@@ -21,12 +21,13 @@ export const TextInputBasic = ({
 }) => {
   return (
     <Flex direction={{ default: 'column' }}>
-      <TextInputGroup isDisabled={!isWriteAccessLoading && !hasWriteAccess}>
+      <TextInputGroup>
         <TextInputGroupMain
           value={textValue}
           onChange={(_event, value) => setTextValue(value)}
         />
         <TextInput
+          isDisabled={!isWriteAccessLoading && !hasWriteAccess}
           value={textValue}
           type="text"
           validated={!isLoading && verifiedStatus === 'error' && verifiedStatus}

--- a/src/Components/TableComponents/TextInputBasic.js
+++ b/src/Components/TableComponents/TextInputBasic.js
@@ -12,14 +12,16 @@ import {
 import { CheckCircleIcon, InProgressIcon } from '@patternfly/react-icons';
 
 export const TextInputBasic = ({
-  textValue,
-  setTextValue,
-  verifiedStatus,
+  hasWriteAccess,
   isLoading,
+  isWriteAccessLoading,
+  setTextValue,
+  textValue,
+  verifiedStatus,
 }) => {
   return (
     <Flex direction={{ default: 'column' }}>
-      <TextInputGroup>
+      <TextInputGroup isDisabled={!isWriteAccessLoading && !hasWriteAccess}>
         <TextInputGroupMain
           value={textValue}
           onChange={(_event, value) => setTextValue(value)}
@@ -51,8 +53,10 @@ export const TextInputBasic = ({
 };
 
 TextInputBasic.propTypes = {
-  textValue: PropTypes.string,
-  setTextValue: PropTypes.func,
-  verifiedStatus: PropTypes.string,
+  hasWriteAccess: PropTypes.bool,
   isLoading: PropTypes.string,
+  isWriteAccessLoading: PropTypes.bool,
+  setTextValue: PropTypes.func,
+  textValue: PropTypes.string,
+  verifiedStatus: PropTypes.string,
 };

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -1,7 +1,5 @@
 import { useFlag, useFlagsStatus } from '@unleash/proxy-client-react';
 import { useMutation } from '@apollo/client';
-import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
-import { RBACPermissions } from '../Components/Common';
 import { DELETE_MATCH } from '../operations/mutations';
 
 export const useFeatureFlag = (flag) => {
@@ -17,20 +15,20 @@ export const useNewMatchesFeatureFlag = () =>
   useFeatureFlag('insights.malware.matches');
 
 export const useActionsConfig = (
+  isWriteAccessLoading,
+  hasWriteAccess,
   selectedMatches,
   fetchDetailsTable,
   fetchDetailsTableGroups,
   setSelectedMatches
 ) => {
   const [deleteMatch] = useMutation(DELETE_MATCH);
-  const { hasAccess: hasDeleteAccess, isLoading: isDeleteAccessLoading } =
-    usePermissions('malware-detection', RBACPermissions.write);
 
   return [
     '',
     {
       label: 'Delete matches',
-      props: !isDeleteAccessLoading && !hasDeleteAccess,
+      props: { isDisabled: !isWriteAccessLoading && !hasWriteAccess },
       onClick: () => {
         try {
           deleteMatch({


### PR DESCRIPTION
Disable functionality and block edit and delete features when a user doesn't have edit permissions

To test:
- Set malware write permissions to false.
- Navigate to Signatures->Signature details and Systems->System details
- Expand a row with new matches

The following should be disabled:
- Checkboxes
- Status dropdown
- Text field for notes
- The "Delete matches" option in the kebab on the parent table toolbar

The row kebab should not be visible at all.