### PR TITLE
fix(RHINENG-11797): Fix missing column headers NewMatchesTable

### DIFF
--- a/src/Components/TableComponents/NewMatchesTable.js
+++ b/src/Components/TableComponents/NewMatchesTable.js
@@ -56,19 +56,11 @@ export const NewMatchesTable = ({
     <Table aria-label="Simple table" variant="compact">
       <Thead style={{ borderBottom: '1px solid #d2d2d2' }}>
         <Tr>
-          {Object.values(columnNames).map(
-            (column, idx) =>
-              !isWriteAccessLoading &&
-              hasWriteAccess &&
-              column === 'actions' && (
-                <Th
-                  key={`column-title-${column.name}-${idx}`}
-                  width={column.width}
-                >
-                  {column.name}
-                </Th>
-              )
-          )}
+          {Object.values(columnNames).map((column, idx) => (
+            <Th key={`column-title-${column.name}-${idx}`} width={column.width}>
+              {column.name}
+            </Th>
+          ))}
         </Tr>
       </Thead>
       <Tbody>


### PR DESCRIPTION
To test:

- Go to signatures/systems
- Select a signature/system and click
- Expand an affected system/matched signature

You will see that the column headers are gone. This PR adds them back in.