### PR TITLE
feat(RHINENG-11793): No bell icon when new matches 0

### DIFF
--- a/src/Components/SigDetailsTable/NewSigDetailsTable.js
+++ b/src/Components/SigDetailsTable/NewSigDetailsTable.js
@@ -333,16 +333,23 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
                 ),
               },
               {
-                title: (
-                  <span>
-                    {host.newMatchCount ? (
-                      <Icon style={{ marginRight: '8px' }}>
+                title:
+                  host.newMatchCount > 0 ? (
+                    <span>
+                      <Icon
+                        data-testid="new-matches-bell-icon"
+                        status="info"
+                        style={{ marginRight: '8px' }}
+                      >
                         <BellIcon />
                       </Icon>
-                    ) : null}
-                    {host.newMatchCount?.toLocaleString()}
-                  </span>
-                ),
+                      {host.newMatchCount?.toLocaleString()}
+                    </span>
+                  ) : (
+                    <span className="pf-v5-u-disabled-color-200">
+                      {host.newMatchCount?.toLocaleString()}
+                    </span>
+                  ),
               },
               {
                 title: host.matchCount?.toLocaleString(),

--- a/src/Components/SigDetailsTable/__tests__/NewSigDetailsTable.tests.js
+++ b/src/Components/SigDetailsTable/__tests__/NewSigDetailsTable.tests.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';
 import { useApolloClient, useMutation } from '@apollo/client';
@@ -87,10 +87,12 @@ describe('SigDetailsTable', () => {
       name: /details i dont want to set the world on fire n\/a rhel 8\.0 04 jul 2024 1 1/i,
     });
 
-    useApolloClient.mockReturnValue({
-      query: async () => {
-        return mockSigHitsList;
-      },
+    act(() => {
+      useApolloClient.mockReturnValue({
+        query: async () => {
+          return mockSigHitsList;
+        },
+      });
     });
 
     await userEvent.click(
@@ -206,5 +208,39 @@ describe('SigDetailsTable', () => {
         name: /delete matches/i,
       })
     ).toBeDisabled();
+  });
+
+  it('should render 0 new matches without BellIcon', async () => {
+    render(
+      <IntlProvider locale="en">
+        <Router>
+          <NewSigDetailsTable
+            ruleName="bingo bango bongo"
+            affectedCount={1}
+            isEmptyAccount={false}
+          />
+        </Router>
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('row', {
+          name: /details i dont want to set the world on fire n\/a rhel 8\.0 04 jul 2024 1 1/i,
+        })
+      ).toBeVisible();
+    });
+
+    act(() => {
+      useApolloClient.mockReturnValue({
+        query: async () => {
+          return mockSigHitsList;
+        },
+      });
+    });
+
+    const bellIcon = screen.getAllByTestId('new-matches-bell-icon');
+
+    expect(bellIcon).toHaveLength(1);
   });
 });

--- a/src/Components/SigDetailsTable/__tests__/sigDetailsTable.fixtures.js
+++ b/src/Components/SigDetailsTable/__tests__/sigDetailsTable.fixtures.js
@@ -41,6 +41,7 @@ export const mockSigDetailsTableData = {
                 hostId: 'b9f6b090-8de9-495c-b058-02c72629ed87',
               },
             ],
+            newMatchCount: 0,
           },
         ],
         affectedHosts: {

--- a/src/Components/SysDetailsTable/NewSysDetailsTable.js
+++ b/src/Components/SysDetailsTable/NewSysDetailsTable.js
@@ -253,16 +253,23 @@ const NewSysDetailsTable = ({ systemId }) => {
               ),
             },
             {
-              title: (
-                <span>
-                  {data.newMatchCount ? (
-                    <Icon style={{ marginRight: '8px' }}>
+              title:
+                data.newMatchCount > 0 ? (
+                  <span>
+                    <Icon
+                      data-testid="new-matches-bell-icon"
+                      status="info"
+                      style={{ marginRight: '8px' }}
+                    >
                       <BellIcon />
                     </Icon>
-                  ) : null}
-                  {data.newMatchCount?.toLocaleString()}
-                </span>
-              ),
+                    {data.newMatchCount?.toLocaleString()}
+                  </span>
+                ) : (
+                  <span className="pf-v5-u-disabled-color-200">
+                    {data.newMatchCount?.toLocaleString()}
+                  </span>
+                ),
             },
             {
               title: data.matchCount?.toLocaleString(),

--- a/src/Components/SysDetailsTable/__tests__/NewSysDetailsTable.tests.js
+++ b/src/Components/SysDetailsTable/__tests__/NewSysDetailsTable.tests.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';
 import { useApolloClient, useMutation } from '@apollo/client';
@@ -189,5 +189,35 @@ describe('SysDetailsTable', () => {
         name: /delete matches/i,
       })
     ).toBeDisabled();
+  });
+
+  it('should render 0 new matches without BellIcon', async () => {
+    render(
+      <IntlProvider locale="en">
+        <Router>
+          <NewSysDetailsTable systemId={1234} />
+        </Router>
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('row', {
+          name: /details dalinar matched 27 jun 2024 1 1/i,
+        })
+      ).toBeVisible();
+    });
+
+    act(() => {
+      useApolloClient.mockReturnValue({
+        query: async () => {
+          return mockSysHitsList;
+        },
+      });
+    });
+
+    const bellIcon = screen.getAllByTestId('new-matches-bell-icon');
+
+    expect(bellIcon).toHaveLength(2);
   });
 });

--- a/src/Components/SysDetailsTable/__tests__/sysDetailsTable.fixtures.js
+++ b/src/Components/SysDetailsTable/__tests__/sysDetailsTable.fixtures.js
@@ -61,7 +61,7 @@ export const mockSysDetailsTableData = {
             },
           ],
           name: 'Kaladin',
-          newMatchCount: '1',
+          newMatchCount: '0',
         },
       ],
     },

--- a/src/Components/TableComponents/MatchedDateColumn.js
+++ b/src/Components/TableComponents/MatchedDateColumn.js
@@ -7,9 +7,9 @@ import PropTypes from 'prop-types';
 export const MatchedDateColumn = ({ data, dropdownValue }) => {
   return dropdownValue === 'NOT_REVIEWED' &&
     isNewerThanThirtyDays(data.scanDate) ? (
-    <TextContent style={{ color: 'var(--pf-global--link--Color)' }}>
+    <TextContent>
       <Text component={TextVariants.p}>
-        <Icon data-testid="new-match-bell-icon">
+        <Icon status="info" data-testid="new-match-bell-icon">
           <BellIcon />
         </Icon>{' '}
         {formatDate(data.scanDate)}


### PR DESCRIPTION
New matches column: Remove the Bell icon when the number is 0 AND make the number gray

Remove the bell icon next to 0
Make the 0 text gray

To test:
- Go to signatures/systems
- Select a signature/system and click

See that a system with more than 0 new matches shows a blue bell icon with the number of new matches. If it has 0 new matches, then the bell icon will not be visible and the 0 will be gray.

In addition, if you expand an affected system or matched signature, the dates matched column should show a blue bell icon with the date text in black.