### PR TITLE
feat(RHINENG-11794): remove link from total matches column

### DIFF
--- a/src/Components/SigDetailsTable/NewSigDetailsTable.js
+++ b/src/Components/SigDetailsTable/NewSigDetailsTable.js
@@ -345,11 +345,7 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
                 ),
               },
               {
-                title: (
-                  <InsightsLink to={`/systems/${host.id}`}>
-                    {host.matchCount?.toLocaleString()}
-                  </InsightsLink>
-                ),
+                title: host.matchCount?.toLocaleString(),
               },
             ],
           },

--- a/src/Components/SysDetailsTable/NewSysDetailsTable.js
+++ b/src/Components/SysDetailsTable/NewSysDetailsTable.js
@@ -265,11 +265,7 @@ const NewSysDetailsTable = ({ systemId }) => {
               ),
             },
             {
-              title: (
-                <InsightsLink to={`/signatures/${data.name}`}>
-                  {data.matchCount?.toLocaleString()}
-                </InsightsLink>
-              ),
+              title: data.matchCount?.toLocaleString(),
             },
           ],
         },


### PR DESCRIPTION
Total matches column: Remove the link from the number & make the text black

- Remove the link
- Make the text black

To test:

- Go to signatures/systems
- Select a signature/system and click