### PR TITLE
chore(RHINENG-11795): Resize columns SigDetailsTable

### DIFF
--- a/src/Components/SigDetailsTable/Columns.js
+++ b/src/Components/SigDetailsTable/Columns.js
@@ -5,13 +5,13 @@ export const sigDetailsTableColumns = (isWorkspaceEnabled, intl) => [
   {
     title: intl.formatMessage(messages.name),
     cellFormatters: [expandable],
-    transforms: [sortable, cellWidth(45)],
+    transforms: [sortable, cellWidth(35)],
   },
   {
     title: isWorkspaceEnabled
       ? 'Workspace'
       : intl.formatMessage(messages.group),
-    transforms: [sortable, cellWidth(15)],
+    transforms: [sortable, cellWidth(10)],
   },
   {
     title: intl.formatMessage(messages.os),
@@ -20,11 +20,11 @@ export const sigDetailsTableColumns = (isWorkspaceEnabled, intl) => [
   },
   {
     title: intl.formatMessage(messages.lastMatched),
-    transforms: [sortable, cellWidth(10)],
+    transforms: [sortable, cellWidth(15)],
   },
   {
     title: intl.formatMessage(messages.newMatchCount),
-    transforms: [sortable, cellWidth(10)],
+    transforms: [sortable, cellWidth(15)],
   },
   {
     title: intl.formatMessage(messages.totalMatches),
@@ -33,7 +33,7 @@ export const sigDetailsTableColumns = (isWorkspaceEnabled, intl) => [
         tooltip: intl.formatMessage(messages.totalMatchesNote),
       }),
       sortable,
-      cellWidth(10),
+      cellWidth(15),
     ],
   },
 ];


### PR DESCRIPTION
This PR resizes the Signature Details Table to avoid truncating column headers on smaller resolution screens. The Systems Details Table seems to be okay.

To test:

- Go to signatures/systems
- Select a signature/system and click

Display on a smaller screen and see how many of the column headers beging to truncate.