### PR TITLE
feat(RHINENG-11792): No bellIcon when older than 30 days

### DIFF
--- a/src/Components/TableComponents/MatchedDateColumn.js
+++ b/src/Components/TableComponents/MatchedDateColumn.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import { Icon, Text, TextContent, TextVariants } from '@patternfly/react-core';
 import { BellIcon } from '@patternfly/react-icons';
-import { formatDate } from '../helpers';
+import { formatDate, isNewerThanThirtyDays } from '../helpers';
 import PropTypes from 'prop-types';
 
 export const MatchedDateColumn = ({ data, dropdownValue }) => {
-  return dropdownValue === 'NOT_REVIEWED' ? (
+  return dropdownValue === 'NOT_REVIEWED' &&
+    isNewerThanThirtyDays(data.scanDate) ? (
     <TextContent style={{ color: 'var(--pf-global--link--Color)' }}>
       <Text component={TextVariants.p}>
-        <Icon>
+        <Icon data-testid="new-match-bell-icon">
           <BellIcon />
         </Icon>{' '}
         {formatDate(data.scanDate)}

--- a/src/Components/TableComponents/NewMatchesTableRow.test.js
+++ b/src/Components/TableComponents/NewMatchesTableRow.test.js
@@ -28,7 +28,7 @@ describe('NewMatchesTableRow Tests', () => {
     id: '1',
     justification: 'Initial justification',
     status: 'NOT_REVIEWED',
-    scanDate: '2021-07-21T00:00:00.000Z',
+    scanDate: new Date(),
   };
   const columnNames = {
     scanDate: 'Dates matched',
@@ -101,6 +101,8 @@ describe('NewMatchesTableRow Tests', () => {
       </MockedProvider>
     );
 
+    expect(screen.getByTestId('new-match-bell-icon')).toBeVisible();
+
     const dropdownTrigger = screen.getByLabelText('MenuToggle');
     fireEvent.click(dropdownTrigger);
 
@@ -111,6 +113,8 @@ describe('NewMatchesTableRow Tests', () => {
     await waitFor(() => {
       expect(screen.getByText(/In review/i)).toBeInTheDocument();
     });
+
+    expect(screen.queryAllByTestId('new-match-bell-icon')).toHaveLength(0);
   });
 
   it('renders disabled correctly', async () => {
@@ -154,5 +158,54 @@ describe('NewMatchesTableRow Tests', () => {
         name: /select all rows/i,
       })
     ).toBeDisabled();
+  });
+
+  it('renders dates matched cell with BellIcon correctly', async () => {
+    render(
+      <MockedProvider>
+        <table>
+          <tbody>
+            <tr>
+              <NewMatchesTableRow
+                data={mockData}
+                columnNames={columnNames}
+                hasWriteAccess={true}
+                isWriteAccessLoading={false}
+              />
+            </tr>
+          </tbody>
+        </table>
+      </MockedProvider>
+    );
+
+    expect(screen.queryAllByTestId('new-match-bell-icon')).toHaveLength(1);
+  });
+
+  it('renders dates matched cell without BellIcon correctly', async () => {
+    let oldMatch = {
+      id: '2',
+      justification: 'Initial justification',
+      status: 'NOT_REVIEWED',
+      scanDate: '2021-06-21T00:00:00.000Z',
+    };
+
+    render(
+      <MockedProvider>
+        <table>
+          <tbody>
+            <tr>
+              <NewMatchesTableRow
+                data={oldMatch}
+                columnNames={columnNames}
+                hasWriteAccess={true}
+                isWriteAccessLoading={false}
+              />
+            </tr>
+          </tbody>
+        </table>
+      </MockedProvider>
+    );
+
+    expect(screen.queryAllByTestId('new-match-bell-icon')).toHaveLength(0);
   });
 });

--- a/src/Components/helpers.js
+++ b/src/Components/helpers.js
@@ -53,3 +53,10 @@ ${
     )
     .join('\n');
 };
+
+export const isNewerThanThirtyDays = (inputDate) => {
+  const date = new Date(inputDate).getTime();
+  const thirtyDaysFromNow = new Date().getTime() - 30 * 24 * 60 * 60 * 1000;
+
+  return date > thirtyDaysFromNow;
+};


### PR DESCRIPTION
When a match is older than 30 days, the Dates matched cells in the NewMatchesTable should not show the blue notification bell icon, even if the status of that match is still "NOT_REVIEWED".

We will need to wait for the backend api to return a `newMatchCount` to properly update the "New Matches" column counts for affected systems and matched signatures.

To test:
- Go to signatures/systems
- Select a signature/system and click
- Expand an affected system/matched signature

See that dates older than 30 days do not have the bell icon even when they have a status of Not reviewed. For a code review, you'll need to force an older date in the code to get the desired result.