### PR TITLE
fix(RHINENG-11822): proper table fetch with filtering

### DIFF
--- a/src/Components/SigDetailsTable/NewSigDetailsTable.js
+++ b/src/Components/SigDetailsTable/NewSigDetailsTable.js
@@ -53,7 +53,19 @@ const orderBy = ({ index, direction }) =>
 const tableReducer = (state, action) => {
   switch (action.type) {
     case 'setTableVars':
-      return { ...state, tableVars: { ...state.tableVars, ...action.payload } };
+      return {
+        ...state,
+        tableVars:
+          action.payload.sigMatchStatusFilter?.length === 0
+            ? {
+                ...state.tableVars,
+                sigMatchStatusFilter: undefined,
+              }
+            : {
+                ...state.tableVars,
+                ...action.payload,
+              },
+      };
     case 'setSortBy':
       return {
         ...state,
@@ -124,8 +136,8 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
       console.error('Error fetching data:', error);
     }
 
-    setSigDetailsTableLoading(false);
     setSigDetailsTable(response);
+    setSigDetailsTableLoading(false);
   };
 
   const fetchDetailsTableGroups = async (shouldShowLoading) => {
@@ -144,14 +156,14 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
       console.error('Error fetching data:', error);
     }
 
-    setSigDetailsTableGroupsLoading(false);
     setSigDetailsTableGroups(response);
+    setSigDetailsTableGroupsLoading(false);
   };
 
   useEffect(() => {
-    fetchDetailsTable();
-    fetchDetailsTableGroups();
-  }, []);
+    fetchDetailsTable(true);
+    fetchDetailsTableGroups(true);
+  }, [tableVars]);
 
   const page = tableVars.offset / tableVars.limit + 1;
   const columns = sigDetailsTableColumns(isWorkspaceEnabled, intl);
@@ -371,7 +383,7 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
         sigDetailsTable?.data?.rulesList[0]?.affectedHostsList
       ),
     });
-  }, [intl, sigDetailsTable.data]);
+  }, [intl, sigDetailsTable.data, tableVars]);
 
   useEffect(() => {
     // populates the Group name filter dropdown
@@ -481,6 +493,7 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
             offset: 0,
           },
         });
+        setExpandedRows([]);
       } else {
         itemsToRemove.map((item) => {
           item.value === 'name' &&

--- a/src/Components/SigDetailsTable/__tests__/NewSigDetailsTable.tests.js
+++ b/src/Components/SigDetailsTable/__tests__/NewSigDetailsTable.tests.js
@@ -56,7 +56,7 @@ describe('SigDetailsTable', () => {
     );
 
     expect(
-      screen.getByRole('button', {
+      screen.getByRole('columnheader', {
         name: /new matches/i,
       })
     ).toBeVisible();

--- a/src/Components/SysDetailsTable/NewSysDetailsTable.js
+++ b/src/Components/SysDetailsTable/NewSysDetailsTable.js
@@ -47,7 +47,19 @@ const orderBy = ({ index, direction }) =>
 const tableReducer = (state, action) => {
   switch (action.type) {
     case 'setTableVars':
-      return { ...state, tableVars: { ...state.tableVars, ...action.payload } };
+      return {
+        ...state,
+        tableVars:
+          action.payload.sysMatchStatusFilter?.length === 0
+            ? {
+                ...state.tableVars,
+                sysMatchStatusFilter: undefined,
+              }
+            : {
+                ...state.tableVars,
+                ...action.payload,
+              },
+      };
     case 'setSortBy':
       return {
         ...state,
@@ -107,13 +119,13 @@ const NewSysDetailsTable = ({ systemId }) => {
       console.error('Error fetching data:', error);
     }
 
-    setSysDetailsTableLoading(false);
     setSysDetailsTable(response);
+    setSysDetailsTableLoading(false);
   };
 
   useEffect(() => {
     fetchDetailsTable(true);
-  }, []);
+  }, [tableVars]);
 
   const page = tableVars.offset / tableVars.limit + 1;
   const columns = sysDetailsTableColumns(intl);
@@ -286,7 +298,7 @@ const NewSysDetailsTable = ({ systemId }) => {
 
     !sysDetailsTableLoading &&
       stateSet({ type: 'setRows', payload: rowBuilder(sysDetailsTable.data) });
-  }, [sysDetailsTable.data, sysDetailsTableLoading]);
+  }, [sysDetailsTable.data, sysDetailsTableLoading, tableVars]);
 
   const buildFilterChips = () => {
     const chips = [];
@@ -321,6 +333,7 @@ const NewSysDetailsTable = ({ systemId }) => {
           type: 'setTableVars',
           payload: { ruleName: '', sysMatchStatusFilter: undefined, offset: 0 },
         });
+        setExpandedRows([]);
       } else {
         itemsToRemove.map((item) => {
           if (item.value === 'signature') {

--- a/src/Components/SysDetailsTable/__tests__/NewSysDetailsTable.tests.js
+++ b/src/Components/SysDetailsTable/__tests__/NewSysDetailsTable.tests.js
@@ -53,7 +53,7 @@ describe('SysDetailsTable', () => {
     ).toBeVisible();
   });
 
-  it('should handle status filter', async () => {
+  it('should handle adding and removing status filter', async () => {
     render(
       <IntlProvider locale="en">
         <Router>

--- a/src/Components/TableComponents/NewMatchesTable.js
+++ b/src/Components/TableComponents/NewMatchesTable.js
@@ -39,8 +39,8 @@ export const NewMatchesTable = ({
         },
       });
 
-      setAreMatchesLoading(false);
       setHitlistData(response.data.hitsList);
+      setAreMatchesLoading(false);
     } catch (error) {
       console.error('Error fetching data:', error);
     }
@@ -48,7 +48,7 @@ export const NewMatchesTable = ({
 
   useEffect(() => {
     fetchMatches();
-  }, []);
+  }, [matchStatusFilter]);
 
   return areMatchesLoading || !hitlistData?.length ? (
     <SkeletonTable rows={5} columns={Object.values(columnNames).length} />


### PR DESCRIPTION
Description of Problem
When you apply any filter, sort or pagination change to the Signature Details or System Details tables, the tables don't refetch the data.

How reproducible
100%

Steps to Reproduce
- Navigate to Malware Signatures/Systems
- Click on a Signature or System to go to details table
- Apply any filter, sort or page change

Actual Behavior
The changed data isn't applied to the table

Expected Behavior
Filters, sorting and pagination should change the table