### PR TITLE
feat(RHINENG-11791): New matches table sort by date

### DIFF
--- a/src/operations/queries.js
+++ b/src/operations/queries.js
@@ -290,6 +290,7 @@ export const GET_HITS_TABLE = gql`
     $status: [Acknowledgement!]
   ) {
     hitsList(
+      orderBy: SCAN_DATE_DESC
       status: $status
       condition: { hostId: $hostId, ruleName: $ruleName }
     ) {
@@ -297,7 +298,7 @@ export const GET_HITS_TABLE = gql`
       scanDate
       status
       justification
-      stringMatchesByRuleScanIdList {
+      stringMatchesByRuleScanIdList(orderBy: SCAN_DATE_DESC) {
         source
         stringData
         stringIdentifier


### PR DESCRIPTION
This PR simply adds a sort to the query for HITS_TABLE. It sets a descending sort by match date. We aren't currently offering the ability to change the sort, so for now it will remain default.