### PR TITLE
fix(RHINENG-11860): Fix bulk deleting all matches

### DIFF
--- a/src/Components/SigDetailsTable/Columns.js
+++ b/src/Components/SigDetailsTable/Columns.js
@@ -1,39 +1,74 @@
-import { cellWidth, expandable, sortable, info } from '@patternfly/react-table';
+import React from 'react';
 import messages from '../../Messages';
+import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
+import { DateFormat } from '@redhat-cloud-services/frontend-components';
+import { Icon } from '@patternfly/react-core';
+import { BellIcon } from '@patternfly/react-icons';
 
 export const sigDetailsTableColumns = (isWorkspaceEnabled, intl) => [
   {
     title: intl.formatMessage(messages.name),
-    cellFormatters: [expandable],
-    transforms: [sortable, cellWidth(35)],
+    width: 35,
+    sort: 1,
+    renderFunc: (host) => (
+      <InsightsLink to={`/systems/${host.id}`}>{host.displayName}</InsightsLink>
+    ),
   },
   {
     title: isWorkspaceEnabled
       ? 'Workspace'
       : intl.formatMessage(messages.group),
-    transforms: [sortable, cellWidth(10)],
+    width: 10,
+    sort: 2,
+    renderFunc: (host) =>
+      host.groups?.[0]?.name || intl.formatMessage(messages.notApplicable),
   },
   {
     title: intl.formatMessage(messages.os),
-    key: 'osVersion',
-    transforms: [sortable, cellWidth(10)],
+    width: 10,
+    sort: 3,
+    renderFunc: (host) => `RHEL ${host.osVersion}`,
   },
   {
     title: intl.formatMessage(messages.lastMatched),
-    transforms: [sortable, cellWidth(15)],
+    width: 15,
+    sort: 4,
+    renderFunc: (host) => (
+      <DateFormat
+        date={new Date(host.matches[host.matches.length - 1].scanDate)}
+        type="onlyDate"
+      />
+    ),
   },
   {
     title: intl.formatMessage(messages.newMatchCount),
-    transforms: [sortable, cellWidth(15)],
+    width: 15,
+    sort: 5,
+    renderFunc: (host) => (
+      <span>
+        {host.newMatchCount > 0 ? (
+          <span>
+            <Icon
+              data-testid="new-matches-bell-icon"
+              status="info"
+              style={{ marginRight: '8px' }}
+            >
+              <BellIcon />
+            </Icon>
+            {host.newMatchCount?.toLocaleString()}
+          </span>
+        ) : (
+          <span className="pf-v5-u-disabled-color-200">
+            {host.newMatchCount?.toLocaleString()}
+          </span>
+        )}
+      </span>
+    ),
   },
   {
     title: intl.formatMessage(messages.totalMatches),
-    transforms: [
-      info({
-        tooltip: intl.formatMessage(messages.totalMatchesNote),
-      }),
-      sortable,
-      cellWidth(15),
-    ],
+    width: 15,
+    sort: 6,
+    renderFunc: (host) => host.matchCount?.toLocaleString(),
   },
 ];

--- a/src/Components/SigDetailsTable/NewSigDetailsTable.js
+++ b/src/Components/SigDetailsTable/NewSigDetailsTable.js
@@ -3,40 +3,30 @@ import propTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { useApolloClient } from '@apollo/client';
 import { isEmpty, uniqWith } from 'lodash';
-import { Icon, Pagination, PaginationVariant } from '@patternfly/react-core';
-import {
-  Table,
-  TableBody,
-  TableHeader,
-} from '@patternfly/react-table/deprecated';
+import { Pagination, PaginationVariant } from '@patternfly/react-core';
+import { Table } from '@patternfly/react-table';
 import { SortByDirection } from '@patternfly/react-table';
-import { BellIcon, CheckCircleIcon, SearchIcon } from '@patternfly/react-icons';
-import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
+import { CheckCircleIcon, SearchIcon } from '@patternfly/react-icons';
 import { SkeletonTable } from '@patternfly/react-component-groups';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
 import TableToolbar from '@redhat-cloud-services/frontend-components/TableToolbar';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import {
   GET_SIGNATURE_DETAILS_TABLE,
   GET_SIGNATURE_DETAILS_TABLE_GROUPS,
 } from '../../operations/queries';
-import CodeEditor from '../CodeEditor/CodeEditor';
 import MessageState from '../MessageState/MessageState';
 import messages from '../../Messages';
 import EmptyAccount from '../SharedComponents/EmptyAccount';
 import './SigDetailsTable.scss';
 import { useWorkspaceFeatureFlag } from '../../Utilities/Hooks';
-import {
-  generateCode,
-  matchStatusFilterMap,
-  addRemoveItemInArray,
-} from '../helpers';
+import { matchStatusFilterMap } from '../helpers';
 import { sigDetailsTableColumns } from './Columns';
 import { useActionsConfig } from '../../Utilities/Hooks';
 import { filterValues } from '../constants';
-import { NewMatchesTable } from '../TableComponents/NewMatchesTable';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { RBACPermissions } from '../Common';
+import { DetailsTableHeader } from '../TableComponents/DetailsTableHeader';
+import { SigDetailsTableBody } from './SigDetailsTableBody';
 
 const sortIndices = {
   1: 'DISPLAY_NAME',
@@ -113,30 +103,27 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
     groups: [],
   };
 
-  const [{ tableVars, sortBy, rows, groups }, stateSet] = useReducer(
-    tableReducer,
-    {
-      ...initialState,
-    }
-  );
+  const [{ tableVars, sortBy, groups }, stateSet] = useReducer(tableReducer, {
+    ...initialState,
+  });
 
   const fetchDetailsTable = async (shouldShowLoading) => {
     if (shouldShowLoading) {
       setSigDetailsTableLoading(true);
     }
 
-    let response;
     try {
-      response = await client.query({
+      const response = await client.query({
         query: GET_SIGNATURE_DETAILS_TABLE,
         fetchPolicy: 'no-cache',
         variables: tableVars,
       });
+
+      setSigDetailsTable(response);
     } catch (error) {
       console.error('Error fetching data:', error);
     }
 
-    setSigDetailsTable(response);
     setSigDetailsTableLoading(false);
   };
 
@@ -250,140 +237,29 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
   const onPerPageSelect = (e, perPage) =>
     stateSet({ type: 'setTableVars', payload: { limit: perPage, offset: 0 } });
 
-  const onSort = (e, index, direction) =>
-    stateSet({
-      type: 'setSortBy',
-      payload: { index, direction },
-      tableVars: { orderBy: orderBy({ index, direction }), offset: 0 },
-    });
+  const getSortParams = (columnIndex) => ({
+    sortBy: {
+      index: sortBy.index,
+      direction: sortBy.direction,
+    },
+    onSort: (e, index, direction) => {
+      stateSet({
+        type: 'setSortBy',
+        payload: { index, direction },
+        tableVars: { orderBy: orderBy({ index, direction }), offset: 0 },
+      });
+    },
+    columnIndex,
+  });
 
   const actions = useActionsConfig(
     isWriteAccessLoading,
     hasWriteAccess,
     selectedMatches,
+    setSelectedMatches,
     fetchDetailsTable,
-    fetchDetailsTableGroups,
-    setSelectedMatches
+    fetchDetailsTableGroups
   );
-
-  const getExpandedCells = (host) => {
-    return [
-      {
-        title: (
-          <div>
-            <NewMatchesTable
-              fetchDetailsTable={fetchDetailsTable}
-              hasWriteAccess={hasWriteAccess}
-              hostId={host.id}
-              isWriteAccessLoading={isWriteAccessLoading}
-              matchStatusFilter={tableVars.sigMatchStatusFilter}
-              ruleName={tableVars.ruleName}
-              setSelectedMatches={setSelectedMatches}
-            />
-            <CodeEditor
-              height="250px"
-              code={generateCode(host)}
-              isDownloadEnabled
-              isCopyEnabled
-            />
-          </div>
-        ),
-      },
-    ];
-  };
-
-  const onCollapse = async (e, rowKey, isOpen) => {
-    const collapseRows = [...rows];
-    const host = collapseRows[rowKey + 1].hostData;
-
-    collapseRows[rowKey] = { ...collapseRows[rowKey], isOpen };
-
-    setExpandedRows((prev) => {
-      return addRemoveItemInArray(prev, rowKey);
-    });
-
-    collapseRows[rowKey + 1].cells = getExpandedCells(host);
-
-    stateSet({ type: 'setRows', payload: collapseRows });
-  };
-
-  useEffect(() => {
-    const rowBuilder = (data) =>
-      data?.flatMap((data, key) => {
-        const host = data;
-        return [
-          {
-            rowId: key,
-            isOpen: expandedRows.includes(key * 2) ? true : false,
-            cells: [
-              {
-                title: (
-                  <InsightsLink to={`/systems/${host.id}`}>
-                    {host.displayName}
-                  </InsightsLink>
-                ),
-              },
-              {
-                title: `${
-                  host.groups?.[0]?.name ||
-                  intl.formatMessage(messages.notApplicable)
-                }`,
-              },
-              {
-                title: host.osVersion
-                  ? `RHEL ${host.osVersion}`
-                  : intl.formatMessage(messages.dataNotAvailable),
-              },
-              {
-                title: (
-                  <DateFormat
-                    date={
-                      new Date(host.matches[host.matches.length - 1].scanDate)
-                    }
-                    type="onlyDate"
-                  />
-                ),
-              },
-              {
-                title:
-                  host.newMatchCount > 0 ? (
-                    <span>
-                      <Icon
-                        data-testid="new-matches-bell-icon"
-                        status="info"
-                        style={{ marginRight: '8px' }}
-                      >
-                        <BellIcon />
-                      </Icon>
-                      {host.newMatchCount?.toLocaleString()}
-                    </span>
-                  ) : (
-                    <span className="pf-v5-u-disabled-color-200">
-                      {host.newMatchCount?.toLocaleString()}
-                    </span>
-                  ),
-              },
-              {
-                title: host.matchCount?.toLocaleString(),
-              },
-            ],
-          },
-          {
-            parent: key * 2,
-            hostData: host,
-            fullWidth: true,
-            cells: expandedRows.includes(key * 2) ? getExpandedCells(host) : [],
-          },
-        ];
-      });
-
-    stateSet({
-      type: 'setRows',
-      payload: rowBuilder(
-        sigDetailsTable?.data?.rulesList[0]?.affectedHostsList
-      ),
-    });
-  }, [intl, sigDetailsTable.data, tableVars]);
 
   useEffect(() => {
     // populates the Group name filter dropdown
@@ -556,19 +432,21 @@ const NewSigDetailsTable = ({ ruleName, affectedCount, isEmptyAccount }) => {
         <Table
           className="sigTable"
           aria-label="Signature Details table"
-          rows={rows}
-          cells={columns}
-          onCollapse={onCollapse}
-          onSort={onSort}
-          sortBy={
-            sigDetailsTable?.data?.rulesList[0]?.affectedHosts?.totalCount > 0
-              ? sortBy
-              : undefined
-          }
           isStickyHeader
         >
-          <TableHeader />
-          <TableBody />
+          <DetailsTableHeader columns={columns} getSortParams={getSortParams} />
+          <SigDetailsTableBody
+            columns={columns}
+            data={sigDetailsTable.data?.rulesList[0]?.affectedHostsList}
+            expandedRows={expandedRows}
+            fetchDetailsTable={fetchDetailsTable}
+            hasWriteAccess={hasWriteAccess}
+            isWriteAccessLoading={isWriteAccessLoading}
+            ruleName={tableVars.ruleName}
+            setExpandedRows={setExpandedRows}
+            setSelectedMatches={setSelectedMatches}
+            sigMatchStatusFilter={tableVars.sigMatchStatusFilter}
+          />
         </Table>
       )}
 

--- a/src/Components/SigDetailsTable/SigDetailsTableBody.js
+++ b/src/Components/SigDetailsTable/SigDetailsTableBody.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { DetailsTableRow } from '../TableComponents/DetailsTableRow';
+
+export const SigDetailsTableBody = ({
+  columns,
+  data,
+  expandedRows,
+  fetchDetailsTable,
+  hasWriteAccess,
+  isWriteAccessLoading,
+  ruleName,
+  setExpandedRows,
+  setSelectedMatches,
+  sigMatchStatusFilter,
+}) => {
+  return data?.map((host, rowIndex) => (
+    <DetailsTableRow
+      key={rowIndex}
+      columns={columns}
+      expandedRows={expandedRows}
+      fetchDetailsTable={fetchDetailsTable}
+      hasWriteAccess={hasWriteAccess}
+      host={host}
+      hostId={host.id}
+      isWriteAccessLoading={isWriteAccessLoading}
+      matchStatusFilter={sigMatchStatusFilter}
+      rowIndex={rowIndex}
+      ruleName={ruleName}
+      setExpandedRows={setExpandedRows}
+      setSelectedMatches={setSelectedMatches}
+    />
+  ));
+};

--- a/src/Components/SigDetailsTable/__tests__/NewSigDetailsTable.tests.js
+++ b/src/Components/SigDetailsTable/__tests__/NewSigDetailsTable.tests.js
@@ -78,13 +78,13 @@ describe('SigDetailsTable', () => {
     await waitFor(() => {
       expect(
         screen.getByRole('row', {
-          name: /details i dont want to set the world on fire n\/a rhel 8\.0 04 jul 2024 1 1/i,
+          name: /i dont want to set the world on fire n\/a rhel 8\.0 04 jul 2024 1 1/i,
         })
       ).toBeVisible();
     });
 
     const row = screen.getByRole('row', {
-      name: /details i dont want to set the world on fire n\/a rhel 8\.0 04 jul 2024 1 1/i,
+      name: /i dont want to set the world on fire n\/a rhel 8\.0 04 jul 2024 1 1/i,
     });
 
     act(() => {
@@ -192,7 +192,7 @@ describe('SigDetailsTable', () => {
     await waitFor(() => {
       expect(
         screen.getByRole('row', {
-          name: /details i dont want to set the world on fire n\/a rhel 8\.0 04 jul 2024 1 1/i,
+          name: /i dont want to set the world on fire n\/a rhel 8\.0 04 jul 2024 1 1/i,
         })
       ).toBeVisible();
     });
@@ -226,7 +226,7 @@ describe('SigDetailsTable', () => {
     await waitFor(() => {
       expect(
         screen.getByRole('row', {
-          name: /details i dont want to set the world on fire n\/a rhel 8\.0 04 jul 2024 1 1/i,
+          name: /i dont want to set the world on fire n\/a rhel 8\.0 04 jul 2024 1 1/i,
         })
       ).toBeVisible();
     });

--- a/src/Components/SysDetailsTable/Columns.js
+++ b/src/Components/SysDetailsTable/Columns.js
@@ -1,32 +1,69 @@
-import { cellWidth, expandable, sortable, info } from '@patternfly/react-table';
+import React from 'react';
 import messages from '../../Messages';
+import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
+import StatusLabel from '../StatusLabel/StatusLabel';
+import { DateFormat } from '@redhat-cloud-services/frontend-components';
+import { Icon } from '@patternfly/react-core';
+import { BellIcon } from '@patternfly/react-icons';
 
 export const sysDetailsTableColumns = (intl) => [
   {
     title: intl.formatMessage(messages.sigName),
-    cellFormatters: [expandable],
-    transforms: [sortable, cellWidth(55)],
+    width: 55,
+    sort: 1,
+    renderFunc: (host) => (
+      <InsightsLink to={`/signatures/${host.name}`}>{host.name}</InsightsLink>
+    ),
   },
   {
     title: intl.formatMessage(messages.lastStatus),
-    transforms: [cellWidth(10), sortable],
+    width: 10,
+    sort: 2,
+    renderFunc: (host) => (
+      <StatusLabel
+        isDisabled={host.isDisabled}
+        hasMatch={host.lastStatus}
+        displayMatch
+      />
+    ),
   },
   {
     title: intl.formatMessage(messages.matched),
-    transforms: [sortable, cellWidth(10)],
+    width: 10,
+    sort: 3,
+    renderFunc: (host) => (
+      <DateFormat date={new Date(host.lastMatchDate)} type="onlyDate" />
+    ),
   },
   {
     title: intl.formatMessage(messages.newMatchCount),
-    transforms: [sortable, cellWidth(10)],
+    width: 10,
+    sort: 4,
+    renderFunc: (host) => (
+      <span>
+        {host.newMatchCount > 0 ? (
+          <span>
+            <Icon
+              data-testid="new-matches-bell-icon"
+              status="info"
+              style={{ marginRight: '8px' }}
+            >
+              <BellIcon />
+            </Icon>
+            {host.newMatchCount?.toLocaleString()}
+          </span>
+        ) : (
+          <span className="pf-v5-u-disabled-color-200">
+            {host.newMatchCount?.toLocaleString()}
+          </span>
+        )}
+      </span>
+    ),
   },
   {
     title: intl.formatMessage(messages.totalMatches),
-    transforms: [
-      cellWidth(15),
-      info({
-        tooltip: intl.formatMessage(messages.totalMatchesNote),
-      }),
-      sortable,
-    ],
+    width: 15,
+    sort: 5,
+    renderFunc: (host) => host.matchCount?.toLocaleString(),
   },
 ];

--- a/src/Components/SysDetailsTable/NewSysDetailsTable.js
+++ b/src/Components/SysDetailsTable/NewSysDetailsTable.js
@@ -3,35 +3,23 @@ import propTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { useApolloClient } from '@apollo/client';
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
-import {
-  Table,
-  TableBody,
-  TableHeader,
-} from '@patternfly/react-table/deprecated';
+import { Table } from '@patternfly/react-table';
 import { SortByDirection } from '@patternfly/react-table';
-import { BellIcon, CheckCircleIcon, SearchIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon, SearchIcon } from '@patternfly/react-icons';
 import { SkeletonTable } from '@patternfly/react-component-groups';
-import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 import TableToolbar from '@redhat-cloud-services/frontend-components/TableToolbar';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
-import CodeEditor from '../CodeEditor/CodeEditor';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { GET_SYSTEMS_DETAILS_TABLE_PAGE } from '../../operations/queries';
 import MessageState from '../MessageState/MessageState';
-import StatusLabel from '../StatusLabel/StatusLabel';
 import messages from '../../Messages';
-import { Icon } from '@patternfly/react-core';
-import {
-  generateCode,
-  matchStatusFilterMap,
-  addRemoveItemInArray,
-} from '../helpers';
+import { matchStatusFilterMap } from '../helpers';
 import { sysDetailsTableColumns } from './Columns';
-import { NewMatchesTable } from '../TableComponents/NewMatchesTable';
 import { useActionsConfig } from '../../Utilities/Hooks';
 import { filterValues } from '../constants';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { RBACPermissions } from '../Common';
+import { DetailsTableHeader } from '../TableComponents/DetailsTableHeader';
+import { SysDetailsTableBody } from './SysDetailsTableBody';
 
 const sortIndices = {
   1: 'NAME',
@@ -99,7 +87,7 @@ const NewSysDetailsTable = ({ systemId }) => {
     rows: [],
   };
 
-  const [{ tableVars, sortBy, rows }, stateSet] = useReducer(tableReducer, {
+  const [{ tableVars, sortBy }, stateSet] = useReducer(tableReducer, {
     ...initialState,
   });
 
@@ -108,18 +96,18 @@ const NewSysDetailsTable = ({ systemId }) => {
       setSysDetailsTableLoading(true);
     }
 
-    let response;
     try {
-      response = await client.query({
+      const response = await client.query({
         query: GET_SYSTEMS_DETAILS_TABLE_PAGE,
         fetchPolicy: 'no-cache',
         variables: tableVars,
       });
+
+      setSysDetailsTable(response);
     } catch (error) {
       console.error('Error fetching data:', error);
     }
 
-    setSysDetailsTable(response);
     setSysDetailsTableLoading(false);
   };
 
@@ -177,128 +165,28 @@ const NewSysDetailsTable = ({ systemId }) => {
   const onPerPageSelect = (e, perPage) =>
     stateSet({ type: 'setTableVars', payload: { limit: perPage, offset: 0 } });
 
-  const onSort = (e, index, direction) =>
-    stateSet({
-      type: 'setSortBy',
-      payload: { index, direction },
-      tableVars: { orderBy: orderBy({ index, direction }), offset: 0 },
-    });
+  const getSortParams = (columnIndex) => ({
+    sortBy: {
+      index: sortBy.index,
+      direction: sortBy.direction,
+    },
+    onSort: (e, index, direction) => {
+      stateSet({
+        type: 'setSortBy',
+        payload: { index, direction },
+        tableVars: { orderBy: orderBy({ index, direction }), offset: 0 },
+      });
+    },
+    columnIndex,
+  });
 
   const actions = useActionsConfig(
     isWriteAccessLoading,
     hasWriteAccess,
     selectedMatches,
-    fetchDetailsTable,
-    setSelectedMatches
+    setSelectedMatches,
+    fetchDetailsTable
   );
-
-  const getExpandedCells = (host) => {
-    return [
-      {
-        title: (
-          <div>
-            <NewMatchesTable
-              fetchDetailsTable={fetchDetailsTable}
-              hasWriteAccess={hasWriteAccess}
-              hostId={systemId}
-              isWriteAccessLoading={isWriteAccessLoading}
-              matchStatusFilter={tableVars.sysMatchStatusFilter}
-              ruleName={host.name}
-              setSelectedMatches={setSelectedMatches}
-            />
-            <CodeEditor
-              height="250px"
-              code={generateCode(host)}
-              isDownloadEnabled
-              isCopyEnabled
-            />
-          </div>
-        ),
-      },
-    ];
-  };
-
-  const onCollapse = async (e, rowKey, isOpen) => {
-    const collapseRows = [...rows];
-    const host = collapseRows[rowKey + 1].hostData;
-
-    collapseRows[rowKey] = { ...collapseRows[rowKey], isOpen };
-
-    setExpandedRows((prev) => {
-      return addRemoveItemInArray(prev, rowKey);
-    });
-
-    collapseRows[rowKey + 1].cells = getExpandedCells(host);
-
-    stateSet({ type: 'setRows', payload: collapseRows });
-  };
-
-  useEffect(() => {
-    const rowBuilder = (data) =>
-      data?.host.affectedRulesList.flatMap((data, key) => [
-        {
-          rowId: key,
-          isOpen: expandedRows.includes(key * 2) ? true : false,
-          cells: [
-            {
-              title: (
-                <InsightsLink to={`/signatures/${data.name}`}>
-                  {data.name}
-                </InsightsLink>
-              ),
-            },
-            {
-              title: (
-                <StatusLabel
-                  isDisabled={data.isDisabled}
-                  hasMatch={data.lastStatus}
-                  displayMatch
-                />
-              ),
-            },
-            {
-              title: (
-                <DateFormat
-                  date={new Date(data.lastMatchDate)}
-                  type="onlyDate"
-                />
-              ),
-            },
-            {
-              title:
-                data.newMatchCount > 0 ? (
-                  <span>
-                    <Icon
-                      data-testid="new-matches-bell-icon"
-                      status="info"
-                      style={{ marginRight: '8px' }}
-                    >
-                      <BellIcon />
-                    </Icon>
-                    {data.newMatchCount?.toLocaleString()}
-                  </span>
-                ) : (
-                  <span className="pf-v5-u-disabled-color-200">
-                    {data.newMatchCount?.toLocaleString()}
-                  </span>
-                ),
-            },
-            {
-              title: data.matchCount?.toLocaleString(),
-            },
-          ],
-        },
-        {
-          parent: key * 2,
-          hostData: data,
-          fullWidth: true,
-          cells: expandedRows.includes(key * 2) ? getExpandedCells(data) : [],
-        },
-      ]);
-
-    !sysDetailsTableLoading &&
-      stateSet({ type: 'setRows', payload: rowBuilder(sysDetailsTable.data) });
-  }, [sysDetailsTable.data, sysDetailsTableLoading, tableVars]);
 
   const buildFilterChips = () => {
     const chips = [];
@@ -382,19 +270,20 @@ const NewSysDetailsTable = ({ systemId }) => {
         <Table
           className="sigTable"
           aria-label="Signature Details table"
-          rows={rows}
-          cells={columns}
-          onCollapse={onCollapse}
-          onSort={onSort}
-          sortBy={
-            sysDetailsTable?.data?.host?.affectedRules?.totalCount > 0
-              ? sortBy
-              : undefined
-          }
           isStickyHeader
         >
-          <TableHeader />
-          <TableBody />
+          <DetailsTableHeader columns={columns} getSortParams={getSortParams} />
+          <SysDetailsTableBody
+            columns={columns}
+            data={sysDetailsTable.data?.host}
+            expandedRows={expandedRows}
+            fetchDetailsTable={fetchDetailsTable}
+            hasWriteAccess={hasWriteAccess}
+            isWriteAccessLoading={isWriteAccessLoading}
+            setExpandedRows={setExpandedRows}
+            setSelectedMatches={setSelectedMatches}
+            sysMatchStatusFilter={tableVars.sysMatchStatusFilter}
+          />
         </Table>
       )}
 

--- a/src/Components/SysDetailsTable/SysDetailsTableBody.js
+++ b/src/Components/SysDetailsTable/SysDetailsTableBody.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { DetailsTableRow } from '../TableComponents/DetailsTableRow';
+
+export const SysDetailsTableBody = ({
+  columns,
+  data,
+  expandedRows,
+  fetchDetailsTable,
+  hasWriteAccess,
+  isWriteAccessLoading,
+  setExpandedRows,
+  setSelectedMatches,
+  sysMatchStatusFilter,
+}) => {
+  const hostId = data?.id;
+  return data?.affectedRulesList?.map((host, rowIndex) => (
+    <DetailsTableRow
+      key={rowIndex}
+      columns={columns}
+      expandedRows={expandedRows}
+      fetchDetailsTable={fetchDetailsTable}
+      hasWriteAccess={hasWriteAccess}
+      host={host}
+      hostId={hostId}
+      isWriteAccessLoading={isWriteAccessLoading}
+      matchStatusFilter={sysMatchStatusFilter}
+      rowIndex={rowIndex}
+      ruleName={host.name}
+      setExpandedRows={setExpandedRows}
+      setSelectedMatches={setSelectedMatches}
+    />
+  ));
+};

--- a/src/Components/SysDetailsTable/__tests__/NewSysDetailsTable.tests.js
+++ b/src/Components/SysDetailsTable/__tests__/NewSysDetailsTable.tests.js
@@ -122,14 +122,14 @@ describe('SysDetailsTable', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('row', {
-          name: /details dalinar matched 27 jun 2024 1 1/i,
+        screen.getByRole('cell', {
+          name: /dalinar/i,
         })
       ).toBeVisible();
     });
 
     const row = screen.getByRole('row', {
-      name: /details dalinar matched 27 jun 2024 1 1/i,
+      name: /dalinar matched 27 jun 2024 1 1/i,
     });
 
     useApolloClient.mockReturnValue({
@@ -172,8 +172,8 @@ describe('SysDetailsTable', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('row', {
-          name: /details dalinar matched 27 jun 2024 1 1/i,
+        screen.getByRole('cell', {
+          name: /dalinar/i,
         })
       ).toBeVisible();
     });
@@ -202,8 +202,8 @@ describe('SysDetailsTable', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('row', {
-          name: /details dalinar matched 27 jun 2024 1 1/i,
+        screen.getByRole('cell', {
+          name: /dalinar/i,
         })
       ).toBeVisible();
     });

--- a/src/Components/TableComponents/DetailsTableHeader.js
+++ b/src/Components/TableComponents/DetailsTableHeader.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Thead, Tr, Th } from '@patternfly/react-table';
+
+export const DetailsTableHeader = ({ columns, getSortParams }) => {
+  return (
+    <Thead>
+      <Tr>
+        <Th />
+        {columns.map((column, index) => (
+          <Th
+            key={index}
+            sort={column.sort ? getSortParams(column.sort) : null}
+            width={column.width}
+          >
+            {column.title}
+          </Th>
+        ))}
+      </Tr>
+    </Thead>
+  );
+};
+
+DetailsTableHeader.propTypes = {
+  columns: PropTypes.array,
+  getSortParams: PropTypes.func,
+};

--- a/src/Components/TableComponents/DetailsTableRow.js
+++ b/src/Components/TableComponents/DetailsTableRow.js
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Tr, Tbody, Td } from '@patternfly/react-table';
+import { addRemoveItemInArray, generateCode } from '../helpers';
+import CodeEditor from '../CodeEditor/CodeEditor';
+import { NewMatchesTable } from './NewMatchesTable';
+
+export const DetailsTableRow = ({
+  columns,
+  expandedRows,
+  fetchDetailsTable,
+  hasWriteAccess,
+  host,
+  hostId,
+  isWriteAccessLoading,
+  matchStatusFilter,
+  rowIndex,
+  ruleName,
+  setExpandedRows,
+  setSelectedMatches,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  useEffect(() => {
+    if (expandedRows.includes(rowIndex)) {
+      setIsExpanded(true);
+    }
+  }, []);
+
+  const expandRows = () => {
+    setIsExpanded(!isExpanded);
+    setExpandedRows((prev) => {
+      return addRemoveItemInArray(prev, rowIndex);
+    });
+  };
+
+  return (
+    <Tbody>
+      <Tr>
+        <Td
+          expand={{
+            rowIndex,
+            isExpanded,
+            onToggle: () => expandRows(),
+            expandId: rowIndex,
+          }}
+        />
+        {columns.map((column, idx) => (
+          <Td key={`${host.displayName}-${idx}`}>{column.renderFunc(host)}</Td>
+        ))}
+      </Tr>
+      <Tr isExpanded={isExpanded}>
+        <Td colSpan={7}>
+          <NewMatchesTable
+            fetchDetailsTable={fetchDetailsTable}
+            hasWriteAccess={hasWriteAccess}
+            hostId={hostId}
+            isExpanded={isExpanded}
+            isWriteAccessLoading={isWriteAccessLoading}
+            matchStatusFilter={matchStatusFilter}
+            ruleName={ruleName}
+            setSelectedMatches={setSelectedMatches}
+          />
+        </Td>
+      </Tr>
+      <Tr isExpanded={isExpanded}>
+        <Td colSpan={7}>
+          <CodeEditor
+            height="250px"
+            code={generateCode(host)}
+            isDownloadEnabled
+            isCopyEnabled
+          />
+        </Td>
+      </Tr>
+    </Tbody>
+  );
+};
+
+DetailsTableRow.propTypes = {
+  columns: PropTypes.array,
+  expandedRows: PropTypes.array,
+  fetchDetailsTable: PropTypes.func,
+  hasWriteAccess: PropTypes.bool,
+  host: PropTypes.object,
+  hostId: PropTypes.string,
+  isWriteAccessLoading: PropTypes.bool,
+  matchStatusFilter: PropTypes.array,
+  rowIndex: PropTypes.string,
+  ruleName: PropTypes.string,
+  setExpandedRows: PropTypes.func,
+  setSelectedMatches: PropTypes.func,
+};

--- a/src/Components/TableComponents/NewMatchesTable.js
+++ b/src/Components/TableComponents/NewMatchesTable.js
@@ -10,6 +10,7 @@ export const NewMatchesTable = ({
   fetchDetailsTable,
   hasWriteAccess,
   hostId,
+  isExpanded,
   isWriteAccessLoading,
   matchStatusFilter,
   ruleName,
@@ -40,20 +41,26 @@ export const NewMatchesTable = ({
       });
 
       setHitlistData(response.data.hitsList);
-      setAreMatchesLoading(false);
     } catch (error) {
       console.error('Error fetching data:', error);
     }
+    setAreMatchesLoading(false);
   };
 
   useEffect(() => {
-    fetchMatches();
-  }, [matchStatusFilter]);
+    if (isExpanded) {
+      fetchMatches();
+    }
+  }, [isExpanded, matchStatusFilter]);
 
-  return areMatchesLoading || !hitlistData?.length ? (
+  return areMatchesLoading ? (
     <SkeletonTable rows={5} columns={Object.values(columnNames).length} />
   ) : (
-    <Table aria-label="Simple table" variant="compact">
+    <Table
+      style={{ marginTop: '16px', marginBottom: '16px' }}
+      aria-label="Simple table"
+      variant="compact"
+    >
       <Thead style={{ borderBottom: '1px solid #d2d2d2' }}>
         <Tr>
           {Object.values(columnNames).map((column, idx) => (
@@ -87,6 +94,7 @@ NewMatchesTable.propTypes = {
   fetchDetailsTable: PropTypes.func,
   hasWriteAccess: PropTypes.bool,
   hostId: PropTypes.string,
+  isExpanded: PropTypes.bool,
   isWriteAccessLoading: PropTypes.bool,
   matchStatusFilter: PropTypes.object,
   ruleName: PropTypes.string,

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -18,9 +18,9 @@ export const useActionsConfig = (
   isWriteAccessLoading,
   hasWriteAccess,
   selectedMatches,
+  setSelectedMatches,
   fetchDetailsTable,
-  fetchDetailsTableGroups,
-  setSelectedMatches
+  fetchDetailsTableGroups
 ) => {
   const [deleteMatch] = useMutation(DELETE_MATCH);
 
@@ -29,16 +29,16 @@ export const useActionsConfig = (
     {
       label: 'Delete matches',
       props: { isDisabled: !isWriteAccessLoading && !hasWriteAccess },
-      onClick: () => {
+      onClick: async () => {
         try {
-          deleteMatch({
+          await deleteMatch({
             variables: {
               input: selectedMatches,
             },
           });
+          setSelectedMatches([]);
           fetchDetailsTable && fetchDetailsTable(true);
           fetchDetailsTableGroups && fetchDetailsTableGroups(true);
-          setSelectedMatches([]);
         } catch (error) {
           console.error('Error fetching data:', error);
         }


### PR DESCRIPTION
**Description of Problem**
Assume you have at least 2 Affected systems/Matched signatures for a given Signature/System. If you expand both Affected systems/Matched signatures and then delete every match in the nested table using the checkboxes and bulk delete feature, you will see a failure when the table tries to reload.

**How reproducible**
100%

**Steps to Reproduce**
- Go to Malware and click Signatures/Systems
- Select a signature/system with at least 2 affected systems/matched signatures
- Expand both affected systems/matched signatures
- Use the checkboxes to select every match on the affected system/matched signature at the top level
- Use bulk delete to delete all of the matches

**Actual Behavior**
The top affected system/matched signature is removed and the second one moves in its place, but has an infinite loading match table.

**Expected Behavior**
The top affected system/matched signature is removed and the second one moves in its place and loads all matches correctly.