### PR TITLE
fix(RHINENG-11865): Update new match count

### DIFF
--- a/src/Components/TableComponents/NewMatchesTableRow.js
+++ b/src/Components/TableComponents/NewMatchesTableRow.js
@@ -57,6 +57,16 @@ export const NewMatchesTableRow = ({
             },
           },
         });
+
+        // if the status of a match is changed to Not reviewed or from Not reviewed to any other status, then we call fetchDetailsTable to update the New matches column in the parent table
+        if (
+          (newDropdownValue === 'NOT_REVIEWED' &&
+            dropdownValue !== 'NOT_REVIEWED') ||
+          (newDropdownValue !== 'NOT_REVIEWED' &&
+            dropdownValue === 'NOT_REVIEWED')
+        ) {
+          fetchDetailsTable(false);
+        }
       }
     },
     [executeMutation, data.id, dropdownValue, textValue]

--- a/src/Components/TableComponents/__tests__/NewMatchesTable.tests.js
+++ b/src/Components/TableComponents/__tests__/NewMatchesTable.tests.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { useApolloClient, useMutation } from '@apollo/client';
+import '@testing-library/jest-dom';
+
+import { NewMatchesTable } from '../NewMatchesTable';
+import { mockSigHitsList } from '../../SigDetailsTable/__tests__/sigDetailsTable.fixtures';
+
+jest.mock('@apollo/client');
+jest.mock('@unleash/proxy-client-react', () => ({
+  ...jest.requireActual('@unleash/proxy-client-react'),
+  useFlag: () => true,
+  useFlagsStatus: () => ({ flagsReady: true }),
+}));
+
+describe('NewMatchesTable', () => {
+  let props;
+
+  beforeEach(() => {
+    useApolloClient.mockReturnValue({
+      query: async () => {
+        return mockSigHitsList;
+      },
+    });
+
+    useMutation.mockReturnValue([
+      jest.fn(async () => {
+        return { data: { acknowledgeHits: { clientMutationId: '123' } } };
+      }),
+    ]);
+
+    jest.mock(
+      '@redhat-cloud-services/frontend-components-utilities/RBACHook',
+      () => ({
+        esModule: true,
+        usePermissions: () => ({ hasAccess: true, isLoading: false }),
+      })
+    );
+
+    props = {
+      fetchDetailsTable: jest.fn(),
+      hasWriteAccess: true,
+      hostId: 1,
+      isExpanded: true,
+      isWriteAccessLoading: false,
+      matchStatusFilter: {},
+      ruleName: 'Starfield',
+      setSelectedMatches: jest.fn(),
+    };
+  });
+
+  it('should render New matches column', async () => {
+    render(
+      <IntlProvider locale="en">
+        <Router>
+          <NewMatchesTable {...props} />
+        </Router>
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {
+          name: /menutoggle/i,
+        })
+      ).toBeVisible();
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /menutoggle/i,
+      })
+    );
+
+    await userEvent.click(
+      screen.getByRole('menuitem', {
+        name: /in review/i,
+      })
+    );
+
+    expect(props.fetchDetailsTable).toHaveBeenCalled();
+  });
+});

--- a/src/Components/TableComponents/__tests__/NewMatchesTableRow.test.js
+++ b/src/Components/TableComponents/__tests__/NewMatchesTableRow.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
-import { EDIT_MATCH } from '../../operations/mutations';
+import { EDIT_MATCH } from '../../../operations/mutations';
 import '@testing-library/jest-dom';
-import { NewMatchesTableRow } from './NewMatchesTableRow';
+import { NewMatchesTableRow } from '../NewMatchesTableRow';
 
 const mutationMock = [
   {
@@ -92,6 +92,7 @@ describe('NewMatchesTableRow Tests', () => {
               <NewMatchesTableRow
                 data={mockData}
                 columnNames={columnNames}
+                fetchDetailsTable={jest.fn()}
                 hasWriteAccess={true}
                 isWriteAccessLoading={false}
               />


### PR DESCRIPTION
If I change status of match from Not Reviewed to another status the 'New Matches"  count should be updated without refreshing browser. Similarly if status is set to Not Reviewed the count should be incremented