### PR TITLE
fix(RHINENG-11872): Remove "Last status" column

### DIFF
--- a/src/Components/SysDetailsTable/Columns.js
+++ b/src/Components/SysDetailsTable/Columns.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import messages from '../../Messages';
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
-import StatusLabel from '../StatusLabel/StatusLabel';
 import { DateFormat } from '@redhat-cloud-services/frontend-components';
 import { Icon } from '@patternfly/react-core';
 import { BellIcon } from '@patternfly/react-icons';
@@ -16,20 +15,8 @@ export const sysDetailsTableColumns = (intl) => [
     ),
   },
   {
-    title: intl.formatMessage(messages.lastStatus),
-    width: 10,
-    sort: 2,
-    renderFunc: (host) => (
-      <StatusLabel
-        isDisabled={host.isDisabled}
-        hasMatch={host.lastStatus}
-        displayMatch
-      />
-    ),
-  },
-  {
     title: intl.formatMessage(messages.matched),
-    width: 10,
+    width: 15,
     sort: 3,
     renderFunc: (host) => (
       <DateFormat date={new Date(host.lastMatchDate)} type="onlyDate" />
@@ -37,7 +24,7 @@ export const sysDetailsTableColumns = (intl) => [
   },
   {
     title: intl.formatMessage(messages.newMatchCount),
-    width: 10,
+    width: 15,
     sort: 4,
     renderFunc: (host) => (
       <span>

--- a/src/Components/SysDetailsTable/__tests__/NewSysDetailsTable.tests.js
+++ b/src/Components/SysDetailsTable/__tests__/NewSysDetailsTable.tests.js
@@ -129,7 +129,7 @@ describe('SysDetailsTable', () => {
     });
 
     const row = screen.getByRole('row', {
-      name: /dalinar matched 27 jun 2024 1 1/i,
+      name: /dalinar 27 jun 2024 1 1/i,
     });
 
     useApolloClient.mockReturnValue({


### PR DESCRIPTION
Removing the "Last status" column from the Matched signatures table.