### PR TITLE
Update On-hold to On hold

### DIFF
--- a/src/Components/constants.js
+++ b/src/Components/constants.js
@@ -1,7 +1,7 @@
 export const filterValues = [
   { label: 'Not reviewed', value: 'NOT_REVIEWED' },
   { label: 'In review', value: 'IN_REVIEW' },
-  { label: 'On-hold', value: 'ON_HOLD' },
+  { label: 'On hold', value: 'ON_HOLD' },
   { label: 'Benign - not malicious malware', value: 'BENIGN' },
   { label: 'Malware detection test', value: 'TEST' },
   { label: 'No action - risk accepted', value: 'NO_ACTION' },

--- a/src/Components/helpers.js
+++ b/src/Components/helpers.js
@@ -3,7 +3,7 @@ import { expandMatchMetadata } from './Common';
 export const matchStatusFilterMap = {
   NOT_REVIEWED: 'Not reviewed',
   IN_REVIEW: 'In review',
-  ON_HOLD: 'On-hold',
+  ON_HOLD: 'On hold',
   BENIGN: 'Benign - not malicious malware',
   TEST: 'Malware detection test',
   NO_ACTION: 'No action - risk accepted',


### PR DESCRIPTION
To test:
- Go to signatures/systems
- Click on a signature/system
- Expand an affected system/matched signature

From here you should be able to expand the dropdown in the status column and see the On hold status updated from On-hold. You should also see it in the toolbar filter for Status.