### PR TITLE
System Page: use lastStatus instead of hasMatch for last status column

### DIFF
--- a/src/Components/SysTable/SysTable.js
+++ b/src/Components/SysTable/SysTable.js
@@ -71,8 +71,8 @@ const SysTable = () => {
           { page = 1, per_page: perPage, orderBy, orderDirection, filters }
         ) => {
           value === 'All'
-            ? delete filters.hasMatch
-            : (filters = { ...filters, hasMatch: value });
+            ? delete filters.lastStatus
+            : (filters = { ...filters, lastStatus: value });
           const sortableColumn = findColumnByKey(orderBy);
           const sortBy = appendDirection(
             sortableColumn?.sortBy,

--- a/src/Components/SysTable/constants.js
+++ b/src/Components/SysTable/constants.js
@@ -68,10 +68,10 @@ export const columns = [
   {
     title: intl.formatMessage(messages.lastStatus),
     transforms: [cellWidth(10)],
-    key: 'hasMatch',
-    sortBy: ['HAS_MATCH'],
-    renderFunc: (hasMatch, _, { isDisabled }) => (
-      <StatusLabel isDisabled={isDisabled} hasMatch={hasMatch} displayMatch />
+    key: 'lastStatus',
+    sortBy: ['LAST_STATUS'],
+    renderFunc: (lastStatus, _, { isDisabled }) => (
+      <StatusLabel isDisabled={isDisabled} hasMatch={lastStatus} displayMatch />
     ),
   },
   {

--- a/src/Components/SysTable/constants.test.js
+++ b/src/Components/SysTable/constants.test.js
@@ -69,8 +69,8 @@ describe('mergedColumns', () => {
       {
         title: 'Last status',
         transforms: [expect.any(Function)],
-        key: 'hasMatch',
-        sortBy: ['HAS_MATCH'],
+        key: 'lastStatus',
+        sortBy: ['LAST_STATUS'],
         renderFunc: expect.any(Function),
         props: {},
       },
@@ -146,8 +146,8 @@ describe('mergedColumns', () => {
       {
         title: 'Last status',
         transforms: [expect.any(Function)],
-        key: 'hasMatch',
-        sortBy: ['HAS_MATCH'],
+        key: 'lastStatus',
+        sortBy: ['LAST_STATUS'],
         renderFunc: expect.any(Function),
         props: {},
       },

--- a/src/operations/queries.js
+++ b/src/operations/queries.js
@@ -167,7 +167,7 @@ export const GET_SYSTEM_TABLE = gql`
     $orderBy: [HostsOrderBy!]
     $hostnameOrId: String
     $tags: JSON
-    $hasMatch: Boolean
+    $lastStatus: Boolean
     $hostGroupFilter: [String]
     $osFilter: [String]
   ) {
@@ -177,13 +177,13 @@ export const GET_SYSTEM_TABLE = gql`
       orderBy: $orderBy
       displayName: $hostnameOrId
       hostTags: $tags
-      condition: { hasMatch: $hasMatch }
+      condition: { lastStatus: $lastStatus }
       groupName: $hostGroupFilter
       osVersion: $osFilter
     ) {
       id
       displayName
-      hasMatch
+      lastStatus
       lastScanDate
       lastMatchDate
       totalMatches
@@ -201,7 +201,7 @@ export const GET_SYSTEM_TABLE = gql`
       orderBy: $orderBy
       displayName: $hostnameOrId
       hostTags: $tags
-      condition: { hasMatch: $hasMatch }
+      condition: { lastStatus: $lastStatus }
       groupName: $hostGroupFilter
       osVersion: $osFilter
     ) {
@@ -237,7 +237,6 @@ export const GET_SYSTEMS_DETAILS_TABLE_PAGE = gql`
       id
       updated
       lastMatchDate
-      hasMatch
       affectedRules(
         first: $limit
         offset: $offset


### PR DESCRIPTION
The last status column was tied to the hasMatch data element. 

With this change the last status column is tied to the lastStatus data element.