### PR TITLE
Switch Sig page to lastStatus instead of hasMatch

### DIFF
--- a/src/Components/SigTable/SigTable.js
+++ b/src/Components/SigTable/SigTable.js
@@ -58,7 +58,7 @@ const initialState = {
 };
 const sortIndices = {
   2: 'NAME',
-  3: 'HAS_MATCH',
+  3: 'LAST_STATUS',
   4: 'HOST_COUNT',
   5: 'LAST_MATCH_DATE_NULLS_LAST',
 };
@@ -163,8 +163,8 @@ const SigTable = ({ refetchSigPageData }) => {
 
   const page = tableVars.offset / tableVars.limit + 1;
   const sigTableFiltersInitialState = {
-    items: { hasMatch: 'true', isDisabled: [] },
-    condition: { hasMatch: true, isDisabled: undefined },
+    items: { lastStatus: 'true', isDisabled: [] },
+    condition: { lastStatus: true, isDisabled: undefined },
   };
 
   const updateSelectedSigs = (selectedRows, selected) => {
@@ -343,14 +343,14 @@ const SigTable = ({ refetchSigPageData }) => {
         onChange: (e, value) => {
           const tableFilters = sigTableFilters();
           sigTableFilters({
-            items: { ...tableFilters.items, hasMatch: value },
+            items: { ...tableFilters.items, lastStatus: value },
             condition: {
               ...tableFilters.condition,
-              hasMatch: value === 'all' ? undefined : JSON.parse(value),
+              lastStatus: value === 'all' ? undefined : JSON.parse(value),
             },
           });
         },
-        value: sigTableFilters().items?.hasMatch || 'true',
+        value: sigTableFilters().items?.lastStatus || 'true',
         items: FILTER_CATEGORIES.sig_match.values,
       },
     },
@@ -377,9 +377,9 @@ const SigTable = ({ refetchSigPageData }) => {
     const tableFilters = sigTableFilters();
     if (event === 'add') {
       let matchedMessage = intl.formatMessage(messages.all);
-      if (tableFilters.items?.hasMatch === 'true') {
+      if (tableFilters.items?.lastStatus === 'true') {
         matchedMessage = intl.formatMessage(messages.matched);
-      } else if (tableFilters.items?.hasMatch === 'false') {
+      } else if (tableFilters.items?.lastStatus === 'false') {
         matchedMessage = intl.formatMessage(messages.notMatched);
       }
 
@@ -390,12 +390,12 @@ const SigTable = ({ refetchSigPageData }) => {
       });
     } else if (event === 'remove') {
       const [newValue, newCondition] =
-        tableFilters.items?.hasMatch === 'all'
+        tableFilters.items?.lastStatus === 'all'
           ? ['true', true]
           : ['all', undefined];
       sigTableFilters({
-        items: { ...tableFilters.items, hasMatch: newValue },
-        condition: { ...tableFilters.condition, hasMatch: newCondition },
+        items: { ...tableFilters.items, lastStatus: newValue },
+        condition: { ...tableFilters.condition, lastStatus: newCondition },
       });
     }
   };
@@ -513,7 +513,7 @@ const SigTable = ({ refetchSigPageData }) => {
                 ) : (
                   <StatusLabel
                     isDisabled={sig.isDisabled}
-                    hasMatch={sig.hasMatch}
+                    hasMatch={sig.lastStatus}
                     displayMatch
                   />
                 ),

--- a/src/Components/SigTable/helper.js
+++ b/src/Components/SigTable/helper.js
@@ -1,11 +1,3 @@
-import isEqual from 'lodash/isEqual';
-
-export const isFilterInDefaultState = (currentFilters) => {
-  const defaultfilter = { condition: { hasMatch: true } };
-
-  return isEqual(defaultfilter, currentFilters);
-};
-
 export function formatDate(date = new Date()) {
   const pad = (number) => `${`${number}`.length === 1 ? '0' : ''}${number}`;
   const toFormat = new Date(date);

--- a/src/operations/queries.js
+++ b/src/operations/queries.js
@@ -6,6 +6,7 @@ const Signatures = {
   RuleDetails: gql`
     fragment RuleDetails on Rule {
       hasMatch
+      lastStatus
       id
       lastMatchDate
       name


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/692da48b-41ce-493a-b22a-5cf920bd1021)
The signature page's last status column is now tied to the lastStatus data element. This means it will only consider the most recent upload from each system.