### PR TITLE
fix colSpan on expanded row SigTable

### DIFF
--- a/src/Components/SigTable/SigTable.js
+++ b/src/Components/SigTable/SigTable.js
@@ -223,6 +223,7 @@ const SigTable = ({ refetchSigPageData }) => {
     collapseRows[rowKey + 1].cells = [
       {
         title: <SignatureDescription signature={sig} />,
+        props: { colSpan: columns.length + 2 },
       },
     ];
     stateSet({ type: 'setRows', payload: collapseRows });


### PR DESCRIPTION
To test:
- go to /signatures table
- expand a row of a signature

You will see that there is a strange issue with the row spanning an additional column. This PR sets an explicit colSpan so it works properly.