### PR TITLE
chore(RHINENG-26152): Remove unneeded source feature flag func

### DIFF
--- a/src/Components/SigTable/SigTable.js
+++ b/src/Components/SigTable/SigTable.js
@@ -38,7 +38,6 @@ import matchFilter from '../SysTable/matchFilter';
 import { MATCHED, NOT_MATCHED, RESET_FILTERS } from '../../constants';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import SourceCell from './components/SourceCell';
-import useFeatureFlag from '../../Utilities/useFeatureFlag';
 
 const SOURCE_FILTER_OPTIONS = [
   { label: 'IBM', value: 'IBM' },
@@ -61,21 +60,13 @@ const initialState = {
   rows: [],
   selectedSigs: [],
 };
-const getSortIndices = (isSourceEnabled) =>
-  isSourceEnabled
-    ? {
-        2: 'NAME',
-        3: 'LAST_STATUS',
-        4: 'SOURCE',
-        5: 'HOST_COUNT',
-        6: 'LAST_MATCH_DATE_NULLS_LAST',
-      }
-    : {
-        2: 'NAME',
-        3: 'LAST_STATUS',
-        4: 'HOST_COUNT',
-        5: 'LAST_MATCH_DATE_NULLS_LAST',
-      };
+const getSortIndices = () => ({
+  2: 'NAME',
+  3: 'LAST_STATUS',
+  4: 'SOURCE',
+  5: 'HOST_COUNT',
+  6: 'LAST_MATCH_DATE_NULLS_LAST',
+});
 
 const orderBy = ({ index, direction }, sortIndices) => {
   const orderByVariable = `${sortIndices[index]}_${
@@ -108,8 +99,7 @@ const tableReducer = (state, action) => {
 const SigTable = ({ refetchSigPageData }) => {
   const intl = useIntl();
   const addNotification = useAddNotification();
-  const isSourceEnabled = useFeatureFlag('malware.source_enabled');
-  const sortIndices = getSortIndices(isSourceEnabled);
+  const sortIndices = getSortIndices();
   // TODO: After RBACv1 removal, rename to hasAcknowledgeAccess since this gates signature enable/disable actions.
   const hasAdminAccess = usePermissionCheck(
     'malware-detection',
@@ -168,7 +158,7 @@ const SigTable = ({ refetchSigPageData }) => {
       title: intl.formatMessage(messages.lastStatus),
       transforms: [sortable],
     },
-    ...(isSourceEnabled ? [{ title: 'Source', transforms: [sortable] }] : []),
+    { title: 'Source', transforms: [sortable] },
     {
       title: intl.formatMessage(messages.systems),
       transforms: [sortable],
@@ -207,13 +197,13 @@ const SigTable = ({ refetchSigPageData }) => {
   }, [matchStateValue]);
 
   useEffect(() => {
-    if (isSourceEnabled && externalSourceFilter !== tableVars.sourceFilter) {
+    if (externalSourceFilter !== tableVars.sourceFilter) {
       stateSet({
         type: 'setTableVars',
         payload: { sourceFilter: externalSourceFilter, offset: 0 },
       });
     }
-  }, [externalSourceFilter, isSourceEnabled]);
+  }, [externalSourceFilter]);
 
   const updateSelectedSigs = (selectedRows, selected) => {
     // This function handles adding/removing sigs to/from the selectedSigs when rows are selected/unselected
@@ -372,25 +362,20 @@ const SigTable = ({ refetchSigPageData }) => {
       },
     },
     matchFilter(matchStateValue, setStateValue),
-    ...(isSourceEnabled
-      ? [
-          {
-            label: 'Source',
-            type: 'singleSelect',
-            id: 'source',
-            filterValues: {
-              onChange: (e, value) => {
-                const newValue =
-                  value === tableVars.sourceFilter ? undefined : value;
-                sourceCardFilter(newValue);
-              },
-              value: tableVars.sourceFilter ? [tableVars.sourceFilter] : [],
-              items: SOURCE_FILTER_OPTIONS,
-              placeholder: 'Filter by source',
-            },
-          },
-        ]
-      : []),
+    {
+      label: 'Source',
+      type: 'singleSelect',
+      id: 'source',
+      filterValues: {
+        onChange: (e, value) => {
+          const newValue = value === tableVars.sourceFilter ? undefined : value;
+          sourceCardFilter(newValue);
+        },
+        value: tableVars.sourceFilter ? [tableVars.sourceFilter] : [],
+        items: SOURCE_FILTER_OPTIONS,
+        placeholder: 'Filter by source',
+      },
+    },
   ];
 
   const onSetPage = (e, page) =>
@@ -489,9 +474,7 @@ const SigTable = ({ refetchSigPageData }) => {
       });
     setMatchedFilterChips({ event: 'add', chips });
     setIncludedFilterChips({ event: 'add', chips });
-    if (isSourceEnabled) {
-      setSourceFilterChips({ event: 'add', chips });
-    }
+    setSourceFilterChips({ event: 'add', chips });
     return chips;
   };
 
@@ -507,9 +490,7 @@ const SigTable = ({ refetchSigPageData }) => {
           type: 'setTableVars',
           payload: { ruleName: '' },
         });
-        if (isSourceEnabled) {
-          sourceCardFilter(undefined);
-        }
+        sourceCardFilter(undefined);
       } else {
         itemsToRemove.map((item) => {
           item.value === 'name' &&
@@ -576,17 +557,13 @@ const SigTable = ({ refetchSigPageData }) => {
                   />
                 ),
               },
-              ...(isSourceEnabled
-                ? [
-                    {
-                      title: sig.isDisabled ? (
-                        intl.formatMessage(messages.notApplicable)
-                      ) : (
-                        <SourceCell source={sig.source} />
-                      ),
-                    },
-                  ]
-                : []),
+              {
+                title: sig.isDisabled ? (
+                  intl.formatMessage(messages.notApplicable)
+                ) : (
+                  <SourceCell source={sig.source} />
+                ),
+              },
               {
                 title: sig.isDisabled ? (
                   intl.formatMessage(messages.notApplicable)

--- a/src/Components/SysDetailsTable/Columns.js
+++ b/src/Components/SysDetailsTable/Columns.js
@@ -7,31 +7,27 @@ import { BellIcon } from '@patternfly/react-icons';
 import NewMatchesColumnTitle from '../TableComponents/NewMatchesColumnTitle';
 import SourceCell from '../SigTable/components/SourceCell';
 
-export const sysDetailsTableColumns = (intl, isSourceEnabled) => [
+export const sysDetailsTableColumns = (intl) => [
   {
     title: intl.formatMessage(messages.sigName),
-    width: isSourceEnabled ? 40 : 45,
+    width: 40,
     sort: 1,
     renderFunc: (host) => (
       <InsightsLink to={`/signatures/${host.name}`}>{host.name}</InsightsLink>
     ),
   },
-  ...(isSourceEnabled
-    ? [
-        {
-          title: 'Source',
-          width: 15,
-          sort: 2,
-          renderFunc: (host) => (
-            <SourceCell source={host.source} metadata={host.metadata} />
-          ),
-        },
-      ]
-    : []),
+  {
+    title: 'Source',
+    width: 15,
+    sort: 2,
+    renderFunc: (host) => (
+      <SourceCell source={host.source} metadata={host.metadata} />
+    ),
+  },
   {
     title: intl.formatMessage(messages.matched),
     width: 15,
-    sort: isSourceEnabled ? 3 : 2,
+    sort: 3,
     renderFunc: (host) => (
       <DateFormat date={new Date(host.lastMatchDate)} type="onlyDate" />
     ),
@@ -39,7 +35,7 @@ export const sysDetailsTableColumns = (intl, isSourceEnabled) => [
   {
     title: <NewMatchesColumnTitle />,
     width: 15,
-    sort: isSourceEnabled ? 4 : 3,
+    sort: 4,
     renderFunc: (host) => (
       <span>
         {host.newMatchCount > 0 ? (
@@ -66,7 +62,7 @@ export const sysDetailsTableColumns = (intl, isSourceEnabled) => [
   {
     title: intl.formatMessage(messages.totalMatches),
     width: 15,
-    sort: isSourceEnabled ? 5 : 4,
+    sort: 5,
     renderFunc: (host) => host.matchCount?.toLocaleString(),
   },
 ];

--- a/src/Components/SysDetailsTable/SysDetailsTable.js
+++ b/src/Components/SysDetailsTable/SysDetailsTable.js
@@ -22,7 +22,6 @@ import { DetailsTableHeader } from '../TableComponents/DetailsTableHeader';
 import { SysDetailsTableBody } from './SysDetailsTableBody';
 import useMalwareSearchParams from '../hooks/useMalwareSearchParams';
 import { getSource } from '../SigTable/components/SourceCell';
-import useFeatureFlag from '../../Utilities/useFeatureFlag';
 
 const sortIndices = {
   1: 'NAME',
@@ -66,7 +65,6 @@ const tableReducer = (state, action) => {
 
 const SysDetailsTable = ({ systemId }) => {
   const intl = useIntl();
-  const isSourceEnabled = useFeatureFlag('malware.source_enabled');
   const client = useApolloClient();
   const { hasAccess: hasWriteAccess, isLoading: isWriteAccessLoading } =
     usePermissionCheck('malware-detection', RBACPermissions.write);
@@ -138,7 +136,7 @@ const SysDetailsTable = ({ systemId }) => {
 
     const host = sysDetailsTable.data.host;
 
-    if (!isSourceEnabled || !sourceFilter) {
+    if (!sourceFilter) {
       return host;
     }
 
@@ -161,7 +159,7 @@ const SysDetailsTable = ({ systemId }) => {
   const filteredHostData = getFilteredHostData();
 
   const page = tableVars.offset / tableVars.limit + 1;
-  const columns = sysDetailsTableColumns(intl, isSourceEnabled);
+  const columns = sysDetailsTableColumns(intl);
 
   const filterConfigItems = [
     {
@@ -195,23 +193,19 @@ const SysDetailsTable = ({ systemId }) => {
         }),
       },
     },
-    ...(isSourceEnabled
-      ? [
-          {
-            label: 'source',
-            type: 'singleSelect',
-            id: 'source',
-            filterValues: {
-              onChange: (e, value) => {
-                setSourceFilter(value === sourceFilter ? undefined : value);
-                setExpandedRows([]);
-              },
-              value: sourceFilter ? [sourceFilter] : [],
-              items: sourceFilterItems,
-            },
-          },
-        ]
-      : []),
+    {
+      label: 'source',
+      type: 'singleSelect',
+      id: 'source',
+      filterValues: {
+        onChange: (e, value) => {
+          setSourceFilter(value === sourceFilter ? undefined : value);
+          setExpandedRows([]);
+        },
+        value: sourceFilter ? [sourceFilter] : [],
+        items: sourceFilterItems,
+      },
+    },
   ];
 
   const onSetPage = (e, page) =>
@@ -261,8 +255,7 @@ const SysDetailsTable = ({ systemId }) => {
           value: status,
         })),
       });
-    isSourceEnabled &&
-      sourceFilter &&
+    sourceFilter &&
       chips.push({
         category: 'Source',
         value: 'source',
@@ -278,7 +271,7 @@ const SysDetailsTable = ({ systemId }) => {
     showDeleteButton:
       tableVars?.ruleName !== '' ||
       tableVars?.status !== undefined ||
-      (isSourceEnabled && sourceFilter !== undefined),
+      sourceFilter !== undefined,
     onDelete: (event, itemsToRemove, isAll) => {
       if (isAll) {
         setSearchParams({});

--- a/src/Components/SysDetailsTable/__tests__/SysDetailsTable.tests.js
+++ b/src/Components/SysDetailsTable/__tests__/SysDetailsTable.tests.js
@@ -8,7 +8,7 @@ import '@testing-library/jest-dom';
 
 jest.mock('../../../Utilities/useFeatureFlag', () => ({
   __esModule: true,
-  default: (flag) => flag === 'malware.source_enabled',
+  default: () => false,
 }));
 
 import SysDetailsTable from '../SysDetailsTable';

--- a/src/Routes/Signatures/Details.js
+++ b/src/Routes/Signatures/Details.js
@@ -50,7 +50,6 @@ import AiSummary from '../../Components/AiSummary/AiSummary';
 
 const Details = () => {
   const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
-  const isSourceEnabled = useFeatureFlag('malware.source_enabled');
   const isAiSummaryEnabled = useFeatureFlag('malware.ai_summary');
 
   const intl = useIntl();
@@ -343,17 +342,15 @@ const Details = () => {
                     sigMetadata?.usage,
                   )}
                 </GridItem>
-                {isSourceEnabled && (
-                  <GridItem xl2={3} lg={6} md={5} sm={12}>
-                    {detailBlock(
-                      'Source',
-                      <SourceCell
-                        source={sigDetailsData?.source}
-                        metadata={sigMetadata}
-                      />,
-                    )}
-                  </GridItem>
-                )}
+                <GridItem xl2={3} lg={6} md={5} sm={12}>
+                  {detailBlock(
+                    'Source',
+                    <SourceCell
+                      source={sigDetailsData?.source}
+                      metadata={sigMetadata}
+                    />,
+                  )}
+                </GridItem>
                 <GridItem xl2={5} md={4} sm={12}>
                   {detailBlock(
                     intl.formatMessage(messages.lastmatch),

--- a/src/Routes/Signatures/Signatures.js
+++ b/src/Routes/Signatures/Signatures.js
@@ -28,7 +28,6 @@ import { useFeatureFlag } from '../../Utilities/Hooks';
 
 const Signatures = () => {
   const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
-  const isSourceEnabled = useFeatureFlag('malware.source_enabled');
 
   const intl = useIntl();
   const { data, loading, error, refetch } = useQuery(GET_SIGNATURE_PAGE);
@@ -98,15 +97,13 @@ const Signatures = () => {
           />
         )}
 
-        {isSourceEnabled && (
-          <div className="ins-l-sourceCardsRow">
-            <SourceCards
-              ibmCount={data?.ruleStats?.ibmCount || 0}
-              crowdstrikeCount={data?.ruleStats?.crowdstrikeCount || 0}
-              loading={loading}
-            />
-          </div>
-        )}
+        <div className="ins-l-sourceCardsRow">
+          <SourceCards
+            ibmCount={data?.ruleStats?.ibmCount || 0}
+            crowdstrikeCount={data?.ruleStats?.crowdstrikeCount || 0}
+            loading={loading}
+          />
+        </div>
 
         <Grid hasGutter>
           <GridItem lg={6} md={12}>

--- a/src/Routes/Systems/Details.js
+++ b/src/Routes/Systems/Details.js
@@ -27,11 +27,9 @@ import Breadcrumb from '../../Components/Breadcrumb/Breadcrumb';
 import SysDetailsTable from '../../Components/SysDetailsTable/SysDetailsTable';
 import messages from '../../Messages';
 import { totalMatchesTitle } from '../../Components/Common';
-import useFeatureFlag from '../../Utilities/useFeatureFlag';
 
 const Details = () => {
   const intl = useIntl();
-  const isSourceEnabled = useFeatureFlag('malware.source_enabled');
   const { id: sysId } = useParams();
   const { data, loading } = useQuery(GET_SYSTEMS_DETAILS_PAGE, {
     variables: { id: sysId },
@@ -125,11 +123,7 @@ const Details = () => {
                       {intl.formatMessage(messages.lastScanCoverageCount, {
                         count:
                           Number(sigPageData?.ruleStats?.ibmCount || 0) +
-                          (isSourceEnabled
-                            ? Number(
-                                sigPageData?.ruleStats?.crowdstrikeCount || 0,
-                              )
-                            : 0),
+                          Number(sigPageData?.ruleStats?.crowdstrikeCount || 0),
                       })}
                     </p>
                   )}


### PR DESCRIPTION
-  Removes functionality for feature flag gating source and Crowdstrike functionality and displays this as default now.
- Previously we wanted to gate production for release of this feature. Now it is unnecessary

## Summary by Sourcery

Remove the malware source feature flag and make source-related UI and filtering always available across signatures and systems views.

New Features:
- Always display source columns, filters, and summary cards for signatures and system details without gating them behind a feature flag.

Enhancements:
- Simplify table configuration and column ordering now that source is an unconditional part of the data model.
- Streamline details views to always show source information and include CrowdStrike counts in coverage metrics.