### PR TITLE
fix(SigList): default signature list to show matched signatures

### DIFF
--- a/src/Components/SigTable/SigTable.cy.js
+++ b/src/Components/SigTable/SigTable.cy.js
@@ -61,8 +61,9 @@ describe('SigTable', () => {
     // reset
     cy.get('button').contains('Reset filters').click();
 
-    // check chips reset
-    cy.get(PF6(CHIP_GROUP)).should('have.length', 0);
+    // check chips reset to default (only "Matched" chip remains)
+    cy.get(PF6(CHIP_GROUP)).should('have.length', 1);
+    hasChip('Status', 'Matched');
   });
 
   it("'Signature' filter box correctly updates chips", () => {
@@ -89,23 +90,19 @@ describe('SigTable', () => {
     // reset
     cy.get('button').contains('Reset filters').click();
 
-    // check chips reset
-    cy.get(PF6(CHIP_GROUP)).should('have.length', 0);
+    // check chips reset to default (only "Matched" chip remains)
+    cy.get(PF6(CHIP_GROUP)).should('have.length', 1);
+    hasChip('Status', 'Matched');
   });
 
   it("'Status' filter box correctly updates chips", () => {
+    // default should show "Matched" chip
+    hasChip('Status', 'Matched');
+
     // select the filter
     selectConditionalFilterOption('Status');
 
-    // select first option
-    cy.get(CONDITIONAL_FILTER).contains('Filter by status').click();
-    cy.get(MENU_ITEM).contains('Matched').click();
-    cy.get(CONDITIONAL_FILTER).contains('Filter by status').click();
-
-    // check chips updated
-    hasChip('Status', 'Matched');
-
-    // select second option
+    // select "Not matched" option
     cy.get(CONDITIONAL_FILTER).contains('Filter by status').click();
     cy.get(MENU_ITEM).contains('Not matched').click();
     cy.get(CONDITIONAL_FILTER).contains('Filter by status').click();
@@ -116,25 +113,28 @@ describe('SigTable', () => {
     // reset
     cy.get('button').contains('Reset filters').click();
 
-    // check chips reset
-    cy.get(PF6(CHIP_GROUP)).should('have.length', 0);
+    // check chips reset to default (only "Matched" chip remains)
+    cy.get(PF6(CHIP_GROUP)).should('have.length', 1);
+    hasChip('Status', 'Matched');
   });
 
   it("'Reset filters' button works", () => {
-    // check that no default chips are present
-    cy.get(PF6(CHIP_GROUP)).should('have.length', 0);
-
-    // apply a filter to create a chip
-    selectConditionalFilterOption('Status');
-    cy.get(CONDITIONAL_FILTER).contains('Filter by status').click();
-    cy.get(MENU_ITEM).contains('Matched').click();
-    cy.get(CONDITIONAL_FILTER).contains('Filter by status').click();
+    // check that the default "Matched" chip is present
+    cy.get(PF6(CHIP_GROUP)).should('have.length', 1);
     hasChip('Status', 'Matched');
+
+    // apply an additional filter
+    selectConditionalFilterOption('Signature');
+    cy.get('[aria-label="text input"]').click();
+    cy.get('[aria-label="text input"]').type('TestSig');
+    cy.get('[aria-label="text input"]').type('{enter}');
+    hasChip('Signature', 'TestSig');
 
     // reset filters
     cy.get('button').contains('Reset filters').click();
 
-    // check that chips are cleared
-    cy.get(PF6(CHIP_GROUP)).should('have.length', 0);
+    // check that only the default "Matched" chip remains
+    cy.get(PF6(CHIP_GROUP)).should('have.length', 1);
+    hasChip('Status', 'Matched');
   });
 });

--- a/src/Components/SigTable/SigTable.js
+++ b/src/Components/SigTable/SigTable.js
@@ -172,10 +172,10 @@ const SigTableInner = ({ refetchSigPageData, hasAdminAccess }) => {
 
   const page = tableVars.offset / tableVars.limit + 1;
   const sigTableFiltersInitialState = {
-    items: { hasMatch: 'all', isDisabled: [] },
-    condition: { hasMatch: undefined, isDisabled: undefined },
+    items: { hasMatch: true, isDisabled: [] },
+    condition: { hasMatch: true, isDisabled: undefined },
   };
-  const [matchStateValue, setStateValue] = useState(undefined);
+  const [matchStateValue, setStateValue] = useState('matched');
   const externalSourceFilter = useReactiveVar(sourceCardFilter);
 
   useEffect(() => {
@@ -486,7 +486,7 @@ const SigTableInner = ({ refetchSigPageData, hasAdminAccess }) => {
     onDelete: (event, itemsToRemove, isAll) => {
       if (isAll) {
         sigTableFilters(sigTableFiltersInitialState);
-        setStateValue(undefined);
+        setStateValue('matched');
         stateSet({
           type: 'setTableVars',
           payload: { ruleName: '' },


### PR DESCRIPTION
RHINENG-25951
Change the SigTable default filter from showing all signatures to showing only matched signatures, aligning it with the SysTable behavior. Update reset-filters to restore the matched default rather than clearing the filter entirely, and update Cypress tests accordingly.

## Summary by Sourcery

Default the signature table to show only matched signatures and keep this default when filters are reset.

Bug Fixes:
- Ensure the SigTable initial filter shows only matched signatures instead of all signatures.
- Ensure the Reset filters action restores the default matched-only view rather than clearing all filters.

Tests:
- Update SigTable Cypress tests to expect the default matched filter chip and its preservation after resetting filters.