### PR TITLE
Add robust parseSourcesList to handle all aiSources formats

### DIFF
--- a/src/Components/AiPanel/AiPanel.js
+++ b/src/Components/AiPanel/AiPanel.js
@@ -20,12 +20,40 @@ import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 import useOnRouteChange from '../../hooks/useOnRouteChange';
 
+const parseSourcesList = (aiSources) => {
+  if (!aiSources) return [];
+  const trimmed = aiSources.trim();
+  if (!trimmed || trimmed === '{}' || trimmed === '[]') return [];
+
+  // JSON array, e.g. ["url1","url2"]
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) return parsed;
+    } catch {
+      // fall through
+    }
+  }
+
+  // Curly-brace delimited, e.g. {"url1","url2"} — swap braces to brackets and parse
+  if (trimmed.startsWith('{')) {
+    try {
+      return JSON.parse(trimmed.replace('{', '[').replace('}', ']'));
+    } catch {
+      // fall through
+    }
+  }
+
+  // Newline-separated plain text
+  return trimmed
+    .split(/\n+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+};
+
 const AiPanel = ({ toggleDrawer, aiDetails, aiSources }) => {
   const [activeTab, setActiveTab] = useState();
-  const sourcesList = JSON.parse(
-    // TODO: Fix output on backend
-    aiSources.replace('{', '[').replace('}', ']') || '[]',
-  );
+  const sourcesList = parseSourcesList(aiSources);
 
   const {
     drawerActions: { setDrawerPanelContent },


### PR DESCRIPTION
Replace the brittle JSON.parse(aiSources.replace('{','[').replace('}',']')) with a parseSourcesList function that handles:
- JSON arrays (new contract): ["url1","url2"]
- Postgres set literals (legacy): {"url1","url2"}
- Plain text / newline-separated (gemini-2.5-pro fallback)
- Empty/null values

Fixes the JSON.parse crash when aiSources is plain text.

## Summary by Sourcery

Introduce a robust aiSources parser to normalize different input formats into a unified sources list for AiPanel.

Bug Fixes:
- Prevent crashes in AiPanel when aiSources is provided as plain text or other non-JSON formats.

Enhancements:
- Support JSON arrays, legacy Postgres set literals, and newline-separated plain text as valid aiSources inputs.